### PR TITLE
Allow task comments to be updated or deleted.  Necessary for HM patch submitted to HiveMind's git.

### DIFF
--- a/service/mantle/work/TaskServices.xml
+++ b/service/mantle/work/TaskServices.xml
@@ -225,11 +225,41 @@ along with this software (see the LICENSE.md file). If not, see
         </in-parameters>
         <actions>
             <service-call name="create#mantle.party.communication.CommunicationEvent" out-map="context"
-                    in-map="[communicationEventTypeId:'Comment', contactMechTypeEnumId:'CmtWebForm', statusId:'CeSent',
+                          in-map="[communicationEventTypeId:'Comment', contactMechTypeEnumId:'CmtWebForm', statusId:'CeSent',
                         fromPartyId:ec.user.userAccount.partyId, entryDate:ec.user.nowTimestamp,
                         contentType:contentType, subject:subject, body:body]"/>
             <service-call name="create#mantle.work.effort.WorkEffortCommEvent"
-                    in-map="[workEffortId:workEffortId, communicationEventId:communicationEventId]"/>
+                          in-map="[workEffortId:workEffortId, communicationEventId:communicationEventId]"/>
+        </actions>
+    </service>
+
+    <service verb="update" noun="TaskComment">
+        <in-parameters>
+            <parameter name="workEffortId" required="true"/>
+            <parameter name="communicationEventId" required="true"/>
+            <parameter name="subject"/>
+            <parameter name="body"/>
+            <parameter name="contentType" default-value="text/plain"/>
+        </in-parameters>
+        <actions>
+            <!-- TODO: Updating entryDate would change the order of the comments; is that desirable? -->
+            <service-call name="update#mantle.party.communication.CommunicationEvent" out-map="context"
+                          in-map="[communicationEventId:communicationEventId,
+                        fromPartyId:ec.user.userAccount.partyId,
+                        contentType:contentType, subject:subject, body:body]"/>
+        </actions>
+    </service>
+
+    <service verb="delete" noun="TaskComment">
+        <in-parameters>
+            <parameter name="workEffortId" required="true"/>
+            <parameter name="communicationEventId" required="true"/>
+        </in-parameters>
+        <actions>
+            <service-call name="delete#mantle.work.effort.WorkEffortCommEvent"
+                          in-map="[workEffortId:workEffortId, communicationEventId:communicationEventId]"/>
+            <service-call name="delete#mantle.party.communication.CommunicationEvent"
+                          in-map="communicationEventId:communicationEventId"/>
         </actions>
     </service>
 


### PR DESCRIPTION
…ate the entry timestamp, which is possibly confusing, but changing the entry timestamp can reorder the time entries.  Possibly the last updated stamp is sufficient if it is desired to know if the two are different?