### PR TITLE
Look for existing invoice for orderItem before generating new invoice.

### DIFF
--- a/service/mantle/account/InvoiceServices.xml
+++ b/service/mantle/account/InvoiceServices.xml
@@ -779,7 +779,9 @@ along with this software (see the LICENSE.md file). If not, see
                     <set field="orderHeader" from="shipmentItemSource.'mantle.order.OrderHeader'"/>
                     <script>orderHeaderMap.put(shipmentItemSource.orderId, orderHeader)</script>
                 </if>
-                <set field="invoiceId" from="invoiceIdByOrderPartIdMap[orderItem.orderId + ':' + orderItem.orderPartSeqId]"/>
+                <entity-find-one entity-name="mantle.order.OrderItemBilling" value-field="orderItemBilling"
+                                 auto-field-map="[orderId:orderItem.orderId, orderItemSeqId:orderItem.orderItemSeqId]"/>
+                <set field="invoiceId" from="orderItemBilling?orderItemBilling.invoiceId:invoiceIdByOrderPartIdMap[orderItem.orderId + ':' + orderItem.orderPartSeqId]"/>
 
                 <if condition="!invoiceId">
                     <!-- find the OrderPart for the from/toPartyId, etc -->


### PR DESCRIPTION
In a system where the order of events is:
1. create order
2. generate invoice
3. receive payments
4. approve order
5. send assets / mark assets sent
the invoice was being created again upon sending of the assets. This code checks for each orderItem whether it was included in a previous invoice before attempting to add them to a new one.