### PR TITLE
Changes to support Work Effort scheduling

### DIFF
--- a/service/mantle/work/EventServices.xml
+++ b/service/mantle/work/EventServices.xml
@@ -13,7 +13,6 @@ along with this software (see the LICENSE.md file). If not, see
 <http://creativecommons.org/publicdomain/zero/1.0/>.
 -->
 <services xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://moqui.org/xsd/service-definition-2.1.xsd">
-
     <service verb="get" noun="FullCalendarData">
         <description>Get data to display WorkEffort events with the FullCalender JS library (see http://fullcalendar.io/)</description>
         <in-parameters>
@@ -74,7 +73,13 @@ along with this software (see the LICENSE.md file). If not, see
                 <!-- for events look for start date within the range -->
                 <econditions combine="or">
                     <econditions combine="and">
-                        <econdition field-name="estimatedStartDate" operator="greater-equals" from="startTs"/>
+                        <econditions combine="or">
+                            <econditions combine="and">
+                                <econdition field-name="estimatedStartDate" operator="greater-equals" from="startTs"/>
+                                <econdition field-name="timePeriodTypeId" operator="is-null"/>
+                            </econditions>
+                            <econdition field-name="timePeriodTypeId" operator="is-not-null"/>
+                        </econditions>
                         <econdition field-name="estimatedStartDate" operator="less-equals" from="endTs"/>
                     </econditions>
                     <econditions combine="and">
@@ -82,14 +87,28 @@ along with this software (see the LICENSE.md file). If not, see
                         <econdition field-name="actualStartDate" operator="less-equals" from="endTs"/>
                     </econditions>
                     <econditions combine="and">
-                        <econdition field-name="allDayStart" operator="greater-equals" from="startDate"/>
+                        <econditions combine="or">
+                            <econditions combine="and">
+                                <econdition field-name="allDayStart" operator="greater-equals" from="startDate"/>
+                                <econdition field-name="timePeriodTypeId" operator="is-null"/>
+                            </econditions>
+                            <econdition field-name="timePeriodTypeId" operator="is-not-null"/>
+                        </econditions>
                         <econdition field-name="allDayStart" operator="less-equals" from="endDate"/>
                     </econditions>
                 </econditions>
-                <select-field field-name="workEffortId,purposeEnumId,workEffortName,description,location,timeUomId,allDayStart,allDayEnd"/>
+                <select-field field-name="workEffortId,purposeEnumId,workEffortName,description,location,timeUomId,allDayStart,allDayEnd,timePeriodTypeId"/>
                 <select-field field-name="actualStartDate,actualCompletionDate,actualWorkTime,actualWorkDuration"/>
                 <select-field field-name="estimatedStartDate,estimatedCompletionDate,estimatedWorkTime,estimatedWorkDuration"/>
             </entity-find>
+
+            <script>finalCal = ec.user.nowCalendar; finalCal.setTime(endTs)</script>
+            <script>startCal = ec.user.nowCalendar</script>
+            <script>endCal = ec.user.nowCalendar</script>
+<script>testCal = ec.user.nowCalendar; testCal.setTime(new java.text.SimpleDateFormat("yyyy-MM-dd").parse("2017-03-30"));</script>
+<log level="warn" message="${testCal.getTime()}"/>
+<script>testCal.add(Calendar.MONTH, -1)</script>
+<log level="warn" message="${testCal.getTime()}"/>
 
             <iterate list="workEffortList" entry="workEffortDef">
                 <set field="workEffort" from="workEffortDef"/><!-- put it in the context -->
@@ -104,11 +123,117 @@ along with this software (see the LICENSE.md file). If not, see
                     <set field="start" from="ec.l10n.format(startEndOut.startDate, 'yyyy-MM-dd\'T\'HH:mm:ss')"/>
                     <set field="end" from="ec.l10n.format(startEndOut.endDate, 'yyyy-MM-dd\'T\'HH:mm:ss')"/>
                 </else></if>
+                <entity-find-one entity-name="mantle.party.time.TimePeriodType" value-field="timePeriodType">
+                <field-map field-name="timePeriodTypeId" from="workEffortDef.timePeriodTypeId"/></entity-find-one>
 
-                <if condition="urlGString"><then><set field="url" from="ec.resource.expand(urlGString, '')"/></then>
-                    <else><set field="url" value=""/></else></if>
-                <script>eventList.add([id:workEffort.workEffortId, title:title, start:start, end:end, url:url, allDay:startEndOut.allDay])</script>
+
+                <if condition="timePeriodType != null">
+                    <if condition="timePeriodType.lengthUomId == null">
+                        <service-call name="mantle.work.EventServices.get#TimePeriodTypeFromAssoc" out-map="startMap"
+                            in-map="[timePeriodTypeId:workEffortDef.timePeriodTypeId,start:startEndOut.startDate,end:startEndOut.endDate,startDate:startDate]"/>
+                        <set field="start" from="startMap.start"/>
+                        <set field="end" from="startMap.end"/>
+
+                        <if condition="urlGString"><then><set field="url" from="ec.resource.expand(urlGString, '')"/></then>
+                            <else><set field="url" value=""/></else></if>
+                        <script>eventList.add([id:workEffort.workEffortId, title:title, start:start, end:end, url:url, allDay:startEndOut.allDay])</script>
+
+                    <else>
+                        <if condition="timePeriodType.lengthUomId == 'TF_day'">
+                            <set field="millis" from="timePeriodType.periodLength * 24 * 60 * 60 * 1000" type="long"/>
+                        <else-if condition="timePeriodType.lengthUomId == 'TF_yr'">
+                            <set field="millis" from="timePeriodType.periodLength * 365 * 24 * 60 * 60 * 1000 + Calendar.DST_OFFSET" type="long"/>
+                        </else-if>
+                        </if>
+
+                        <set field="intervalCount" value="0" type="Integer"/>
+                        <set field="intervalMax" from="(long)(1 / timePeriodType.periodLength)" type="Long"/>
+                        <script>startCal.setTime(startEndOut.startDate)</script>
+                        <script>endCal.setTime(startEndOut.endDate)</script>
+                        <set field="prevDST" from="-1" type="int"/>
+                        <while condition="intervalMax &gt; 0 &amp;&amp; intervalCount &lt; intervalMax">
+                            <while condition="startCal.before(finalCal)">
+                                <script>startCal.setTimeInMillis(startCal.getTime().getTime() + millis)</script>
+                                <script>endCal.setTimeInMillis(endCal.getTime().getTime() + millis)</script>
+                                <set field="currDST" from="startCal.get(Calendar.DST_OFFSET)" type="int"/>
+                                <if condition="prevDST != currDST">
+                                    <if condition="currDST &gt; 0 &amp;&amp; prevDST != -1">
+                                        <script>startCal.add(Calendar.MILLISECOND, -currDST); endCal.add(Calendar.MILLISECOND, -currDST)</script>
+                                    <else-if condition="prevDST != -1">
+                                        <script>startCal.add(Calendar.MILLISECOND, prevDST); endCal.add(Calendar.MILLISECOND, prevDST)</script>
+                                    </else-if>
+                                    </if>
+                                    <set field="prevDST" from="startCal.get(Calendar.DST_OFFSET)" type="int"/>
+                                </if>
+                                <if condition="startCal.get(Calendar.YEAR) % 4 == 0">
+                                    <script>startCal.add(Calendar.DAY_OF_YEAR, 1); endCal.add(Calendar.DAY_OF_YEAR, 1);</script>
+                                </if>
+                                <if condition="startCal.getTime() &lt; startTs">
+                                    <continue/>
+                                </if>
+
+                                <set field="start" from="ec.l10n.format(startCal.getTime(), 'yyyy-MM-dd HH:mm:ss.SSS')"/>
+                                <set field="end" from="ec.l10n.format(endCal.getTime(), 'yyyy-MM-dd HH:mm:ss.SSS')"/>
+
+                                <if condition="urlGString"><then><set field="url" from="ec.resource.expand(urlGString, '')"/></then>
+                                    <else><set field="url" value=""/></else></if>
+                                <script>eventList.add([id:workEffort.workEffortId, title:title, start:start, end:end, url:url, allDay:startEndOut.allDay])</script>
+                            </while>
+                            <set field="intervalCount" from="intervalCount + 1" type="Long"/>
+                        </while>
+                    </else>
+                    </if>
+                <else>
+                    <if condition="urlGString"><then><set field="url" from="ec.resource.expand(urlGString, '')"/></then>
+                        <else><set field="url" value=""/></else></if>
+                    <script>eventList.add([id:workEffort.workEffortId, title:title, start:start, end:end, url:url, allDay:startEndOut.allDay])</script>
+                </else>
+                </if>
             </iterate>
+        </actions>
+    </service>
+
+    <service verb="get" noun="TimePeriodTypeFromAssoc">
+        <in-parameters>
+            <parameter name="timePeriodTypeId" required="true"/>
+            <parameter name="start" type="Date" required="true"/>
+            <parameter name="end" type="Date" required="true"/>
+            <parameter name="startDate" type="Date" required="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="start"/>
+            <parameter name="end"/>
+        </out-parameters>
+        <actions>
+            <entity-find entity-name="mantle.party.time.TimePeriodTypeAssoc" list="timePeriodTypeAssocList">
+                <econdition field-name="timePeriodTypeId" from="timePeriodTypeId"/>
+                <select-field field-name="toTimePeriodTypeId,timePeriodTypeAssocTypeEnumId"/>
+            </entity-find>
+            <set field="startEndDiffMillis" from="end.getTime() - start.getTime()"/>
+            <script>cal = ec.user.nowCalendar; cal.setTime(startDate)</script>
+            <set field="currentYear" from="cal.get(Calendar.YEAR)" type="int"/>
+            <script>cal.setTime(start); cal.set(Calendar.YEAR, currentYear)</script>
+            <iterate list="timePeriodTypeAssocList" entry="timePeriodTypeAssoc">
+                <entity-find-one entity-name="mantle.party.time.TimePeriodType" value-field="timePeriodType">
+                    <field-map field-name="timePeriodTypeId" from="timePeriodTypeAssoc.toTimePeriodTypeId"/></entity-find-one>
+                <if condition="timePeriodTypeAssoc.timePeriodTypeAssocTypeEnumId == 'TptaInclude'">
+                    <if condition="timePeriodType.lengthUomId == 'TF_mon_day'">
+                        <script>cal.set(Calendar.DAY_OF_MONTH, timePeriodType.periodLength.intValue())</script>
+                    </if>
+                    <if condition="timePeriodType.lengthUomId == 'TF_wk_day'">
+                        <script>cal.set(Calendar.DAY_OF_WEEK, timePeriodType.periodLength.intValue())</script>
+                    </if>
+                    <if condition="timePeriodType.lengthUomId == 'TF_yr_mon'">
+                        <script>cal.set(Calendar.MONTH, timePeriodType.periodLength.intValue() - 1)</script>
+                    </if>
+                    <if condition="timePeriodType.lengthUomId == 'TF_mon_wk_day'">
+                        <script>cal.set(Calendar.DAY_OF_WEEK_IN_MONTH, timePeriodType.periodLength.intValue())</script>
+                    </if>
+                </if>
+            </iterate>
+            <set field="start" from="ec.l10n.format(cal, 'yyyy-MM-dd\'T\'HH:mm:ss')"/>
+            <script>cal.setTimeInMillis(cal.getTime().getTime() + startEndDiffMillis)</script>
+            <set field="end" from="ec.l10n.format(cal, 'yyyy-MM-dd\'T\'HH:mm:ss')"/>
         </actions>
     </service>
 


### PR DESCRIPTION
This commit represents a proof of concept for using the TimePeriodType entity for scheduling a single Columbus Day WorkEffort (USA_COLD) to prevent having to create a Columbus Day WorkEffort every year.  Columbus day was chosen as the proof of concept holiday because it does not have a fixed date and therefore requires the TimePeriodTypeAssoc entity added to mantle-udm.

Currently the service only supports scheduling daily and yearly tasks.  Additional scheduling still needs to be supported such as biweekly, bimonthly etc. but it is a bit more complicated to implement and I didn't want to dedicate too much effort if using this method for scheduling is incorrect.

If the scheduling method is acceptable then changes for other holidays will be added as well as additional scheduling capabilities. 