### PR TITLE
The defaultToPrimaryPurpose is not working 

### DIFF
--- a/service/mantle/party/ContactServices.xml
+++ b/service/mantle/party/ContactServices.xml
@@ -66,16 +66,16 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="contactMechPurposeId" from="postalContactMechPurposeId"/>
                     <order-by field-name="-fromDate"/>
                 </entity-find>
-                <if condition="defaultToPrimaryPurpose &amp;&amp; !postalPcmList">
-                    <entity-find entity-name="mantle.party.contact.PartyContactMech" list="postalPcmList">
-                        <date-filter/><econdition field-name="partyId"/>
-                        <econdition field-name="contactMechPurposeId" value="PostalPrimary"/>
-                        <order-by field-name="-fromDate"/>
-                    </entity-find>
-                    <if condition="postalPcmList"><set field="postalContactMechPurposeId" value="PostalPrimary"/></if>
-                </if>
-                <set field="postalContactMechId" from="postalPcmList ? postalPcmList[0].contactMechId : null"/>
             </if>
+            <if condition="defaultToPrimaryPurpose &amp;&amp; !postalPcmList">
+                <entity-find entity-name="mantle.party.contact.PartyContactMech" list="postalPcmList">
+                    <date-filter/><econdition field-name="partyId"/>
+                    <econdition field-name="contactMechPurposeId" value="PostalPrimary"/>
+                    <order-by field-name="-fromDate"/>
+                </entity-find>
+                <if condition="postalPcmList"><set field="postalContactMechPurposeId" value="PostalPrimary"/></if>
+            </if>
+            <set field="postalContactMechId" from="postalPcmList ? postalPcmList[0].contactMechId : null"/>
             <entity-find-one entity-name="mantle.party.contact.ContactMech" value-field="postalContactMech">
                 <field-map field-name="contactMechId" from="postalContactMechId"/></entity-find-one>
             <entity-find-one entity-name="mantle.party.contact.PostalAddress" value-field="postalAddress">
@@ -92,17 +92,17 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="contactMechPurposeId" from="telecomContactMechPurposeId"/>
                     <order-by field-name="-fromDate"/>
                 </entity-find>
-                <if condition="defaultToPrimaryPurpose &amp;&amp; !telecomPcmList">
-                    <entity-find entity-name="mantle.party.contact.PartyContactMech" list="telecomPcmList">
-                        <date-filter/><econdition field-name="partyId"/>
-                        <econdition field-name="contactMechPurposeId" value="PhonePrimary"/>
-                        <order-by field-name="-fromDate"/>
-                    </entity-find>
-                    <if condition="telecomPcmList"><set field="telecomContactMechPurposeId" value="PhonePrimary"/></if>
-                </if>
-                <set field="telecomPartyContactMech" from="telecomPcmList ? telecomPcmList[0] : null"/>
-                <set field="telecomContactMechId" from="telecomPartyContactMech?.contactMechId"/>
             </if>
+            <if condition="defaultToPrimaryPurpose &amp;&amp; !telecomPcmList">
+                <entity-find entity-name="mantle.party.contact.PartyContactMech" list="telecomPcmList">
+                    <date-filter/><econdition field-name="partyId"/>
+                    <econdition field-name="contactMechPurposeId" value="PhonePrimary"/>
+                    <order-by field-name="-fromDate"/>
+                </entity-find>
+                <if condition="telecomPcmList"><set field="telecomContactMechPurposeId" value="PhonePrimary"/></if>
+            </if>
+            <set field="telecomPartyContactMech" from="telecomPcmList ? telecomPcmList[0] : null"/>
+            <set field="telecomContactMechId" from="telecomPartyContactMech?.contactMechId"/>
             <entity-find-one entity-name="mantle.party.contact.ContactMech" value-field="telecomContactMech">
                 <field-map field-name="contactMechId" from="telecomContactMechId"/></entity-find-one>
             <entity-find-one entity-name="mantle.party.contact.TelecomNumber" value-field="telecomNumber">
@@ -130,17 +130,17 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="contactMechPurposeId" from="faxContactMechPurposeId"/>
                     <order-by field-name="-fromDate"/>
                 </entity-find>
-                <if condition="defaultToPrimaryPurpose &amp;&amp; !faxPcmList">
-                    <entity-find entity-name="mantle.party.contact.PartyContactMech" list="faxPcmList">
-                        <date-filter/><econdition field-name="partyId"/>
-                        <econdition field-name="contactMechPurposeId" value="PhoneFax"/>
-                        <order-by field-name="-fromDate"/>
-                    </entity-find>
-                    <if condition="faxPcmList"><set field="faxContactMechPurposeId" value="PhoneFax"/></if>
-                </if>
-                <set field="faxPartyContactMech" from="faxPcmList ? faxPcmList[0] : null"/>
-                <set field="faxContactMechId" from="faxPartyContactMech?.contactMechId"/>
             </if>
+            <if condition="defaultToPrimaryPurpose &amp;&amp; !faxPcmList">
+                <entity-find entity-name="mantle.party.contact.PartyContactMech" list="faxPcmList">
+                    <date-filter/><econdition field-name="partyId"/>
+                    <econdition field-name="contactMechPurposeId" value="PhoneFax"/>
+                    <order-by field-name="-fromDate"/>
+                </entity-find>
+                <if condition="faxPcmList"><set field="faxContactMechPurposeId" value="PhoneFax"/></if>
+            </if>
+            <set field="faxPartyContactMech" from="faxPcmList ? faxPcmList[0] : null"/>
+            <set field="faxContactMechId" from="faxPartyContactMech?.contactMechId"/>
             <entity-find-one entity-name="mantle.party.contact.ContactMech" value-field="faxContactMech">
                 <field-map field-name="contactMechId" from="faxContactMechId"/></entity-find-one>
             <entity-find-one entity-name="mantle.party.contact.TelecomNumber" value-field="faxTelecomNumber">
@@ -161,17 +161,17 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="contactMechPurposeId" from="emailContactMechPurposeId"/>
                     <order-by field-name="-fromDate"/>
                 </entity-find>
-                <if condition="defaultToPrimaryPurpose &amp;&amp; !emailPcmList">
-                    <entity-find entity-name="mantle.party.contact.PartyContactMech" list="emailPcmList">
-                        <date-filter/><econdition field-name="partyId"/>
-                        <econdition field-name="contactMechPurposeId" value="EmailPrimary"/>
-                        <order-by field-name="-fromDate"/>
-                    </entity-find>
-                    <if condition="emailPcmList"><set field="emailContactMechPurposeId" value="EmailPrimary"/></if>
-                </if>
-                <set field="emailPartyContactMech" from="emailPcmList ? emailPcmList[0] : null"/>
-                <set field="emailContactMechId" from="emailPartyContactMech?.contactMechId"/>
             </if>
+            <if condition="defaultToPrimaryPurpose &amp;&amp; !emailPcmList">
+                <entity-find entity-name="mantle.party.contact.PartyContactMech" list="emailPcmList">
+                    <date-filter/><econdition field-name="partyId"/>
+                    <econdition field-name="contactMechPurposeId" value="EmailPrimary"/>
+                    <order-by field-name="-fromDate"/>
+                </entity-find>
+                <if condition="emailPcmList"><set field="emailContactMechPurposeId" value="EmailPrimary"/></if>
+            </if>
+            <set field="emailPartyContactMech" from="emailPcmList ? emailPcmList[0] : null"/>
+            <set field="emailContactMechId" from="emailPartyContactMech?.contactMechId"/>
             <entity-find-one entity-name="mantle.party.contact.ContactMech" value-field="emailContactMech">
                 <field-map field-name="contactMechId" from="emailContactMechId"/></entity-find-one>
             <set field="emailAddress" from="emailContactMech?.infoString"/>


### PR DESCRIPTION
The defaultToPrimaryPurpose is not working when service caller didn't specified the value for postalContactMechPurposeId,telecomContactMechPurposeId,faxContactMechPurposeId,emailContactMechPurposeId for their related records
