### PR TITLE
Use method gateway id as higher priority gateway than one defined in payment

### DIFF
--- a/service/mantle/account/PaymentServices.xml
+++ b/service/mantle/account/PaymentServices.xml
@@ -945,9 +945,11 @@ along with this software (see the LICENSE.md file). If not, see
             <!-- use paymentGatewayConfigId from Payment if present -->
             <set field="paymentGatewayConfigId" from="payment.paymentGatewayConfigId"/>
             <!-- see if associated PaymentMethod has a paymentGatewayConfigId first -->
-            <if condition="!paymentGatewayConfigId &amp;&amp; payment.paymentMethodId">
+            <if condition="payment.paymentMethodId">
                 <set field="paymentMethod" from="payment.method"/>
-                <set field="paymentGatewayConfigId" from="paymentMethod?.paymentGatewayConfigId"/>
+                <if condition="paymentMethod.paymentGatewayConfigId">
+                    <set field="paymentGatewayConfigId" from="paymentMethod?.paymentGatewayConfigId"/>
+                </if>
             </if>
             <!-- finally get default for store -->
             <if condition="!paymentGatewayConfigId">


### PR DESCRIPTION
Current implementation when code use payment gateway id from the payment first blocks processing payment methods which use gateways that are not set as the current but still can be processed.

Authorize.Net vs. Braintree is a good example. If user switches to BT then Authorize.Net methods cannot be processed because new payments contain new gateway id (BT). But payment method is correct and contains proper id.