### PR TITLE
Use CurrencyDefault preference when available to define default currencyUomId.

### DIFF
--- a/service/mantle/account/InvoiceServices.xml
+++ b/service/mantle/account/InvoiceServices.xml
@@ -1382,7 +1382,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="thruDate" type="Timestamp" default="ec.user.nowTimestamp">
                 <description>Only TimeEntry records before this date will be included. Defaults to now.</description></parameter>
             <parameter name="createSingleItem" type="Boolean" default="false"/>
-            <parameter name="currencyUomId" default-value="USD"/>
+            <parameter name="currencyUomId" default-value="${ec.user.getPreference('CurrencyDefault') ?: 'USD'}"/>
             <parameter name="ratePurposeEnumId" default-value="RaprClient"><description>If RaprVendor TimeEntry.vendorInvoiceId is
                 populated and time entries with it populated are excluded, otherwise with default of RaprClient TimeEntry.invoiceId is used.</description></parameter>
             <parameter name="workerPartyId"><description>If specified only include time entries from this Party.</description></parameter>

--- a/service/mantle/product/PriceServices.xml
+++ b/service/mantle/product/PriceServices.xml
@@ -50,7 +50,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="priceTypeEnumId" required="true"/>
             <parameter name="quantity" type="BigDecimal" default="1.0"/>
             <parameter name="validDate" type="Timestamp" default="ec.user.nowTimestamp"/>
-            <parameter name="priceUomId" default-value="USD"/>
+            <parameter name="priceUomId" default-value="${ec.user.getPreference('CurrencyDefault') ?: 'USD'}"/>
             <parameter name="pricePurposeEnumId" default-value="PppPurchase"/>
             <parameter name="productStoreId"/><parameter name="vendorPartyId"/><parameter name="customerPartyId"/>
         </in-parameters>
@@ -90,7 +90,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="productId" required="true"/>
             <parameter name="quantity" type="BigDecimal" default="1.0"/>
             <parameter name="validDate" type="Timestamp" default="ec.user.nowTimestamp"/>
-            <parameter name="priceUomId" default-value="USD"/>
+            <parameter name="priceUomId" default-value="${ec.user.getPreference('CurrencyDefault') ?: 'USD'}"/>
             <parameter name="pricePurposeEnumId" default-value="PppPurchase"/>
             <parameter name="productStoreId"/><parameter name="vendorPartyId"/><parameter name="customerPartyId"/>
             <!-- TODO: to support look for records with this first and then with null: <parameter name="agreementId"/> -->
@@ -142,7 +142,7 @@ along with this software (see the LICENSE.md file). If not, see
         <in-parameters>
             <parameter name="productId" required="true"/>
             <parameter name="quantity" type="BigDecimal" default="1"/>
-            <parameter name="priceUomId" default-value="USD"/>
+            <parameter name="priceUomId" default-value="${ec.user.getPreference('CurrencyDefault') ?: 'USD'}"/>
             <parameter name="pricePurposeEnumId" default-value="PppPurchase"/>
 
             <parameter name="productStoreId"/><parameter name="vendorPartyId"/><parameter name="customerPartyId"/>

--- a/service/mantle/work/TimeServices.xml
+++ b/service/mantle/work/TimeServices.xml
@@ -666,7 +666,7 @@ along with this software (see the LICENSE.md file). If not, see
         <in-parameters>
             <parameter name="timeEntryId" required="true"/>
             <!-- TODO: where to get currency... project setting? client or internal org setting? -->
-            <parameter name="rateCurrencyUomId" default-value="USD"/>
+            <parameter name="rateCurrencyUomId" default-value="${ec.user.getPreference('CurrencyDefault') ?: 'USD'}"/>
             <parameter name="resetRates" type="Boolean" default="false"/>
         </in-parameters>
         <out-parameters>


### PR DESCRIPTION
"USD" was hardwired as default value, using CurrencyDefault preference instead for several services.