### PR TITLE
Correctly set field invoiceItemSeqId when creating OrderItemBilling

### DIFF
--- a/service/mantle/account/InvoiceServices.xml
+++ b/service/mantle/account/InvoiceServices.xml
@@ -822,7 +822,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <iterate list="shipmentItemSourceList" entry="shipmentItemSource">
                         <if condition="!shipmentItemSource.invoiceId &amp;&amp; quantityNotShipSourced >= shipmentItemSource.quantity">
                             <set field="shipmentItemSource.invoiceId" from="invoiceId"/>
-                            <set field="shipmentItemSource.invoiceItemSeqId" from="orderItem.invoiceItemSeqId"/>
+                            <set field="shipmentItemSource.invoiceItemSeqId" from="orderItem.orderItemSeqId"/>
                             <entity-update value-field="shipmentItemSource"/>
                             <set field="quantityNotShipSourced" from="quantityNotShipSourced - shipmentItemSource.quantity"/>
                             <set field="curShipmentId" from="shipmentItemSource.shipmentId"/>
@@ -832,7 +832,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                     <!-- now create OrderItemBilling with shipmentId if available -->
                     <service-call name="create#mantle.order.OrderItemBilling"
-                            in-map="oibBaseMap + [invoiceId:invoiceId, invoiceItemSeqId:orderItem.invoiceItemSeqId,
+                            in-map="oibBaseMap + [invoiceId:invoiceId, invoiceItemSeqId:orderItem.orderItemSeqId,
                                 amount:orderItem.unitAmount, quantity:quantityNotBilled, shipmentId:curShipmentId]"/>
                 </if>
             </iterate>

--- a/service/mantle/account/InvoiceServices.xml
+++ b/service/mantle/account/InvoiceServices.xml
@@ -806,7 +806,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <if condition="quantityNotBilled &gt; 0">
                     <!-- create InvoiceItem -->
                     <!-- is prorate by quantity needed? -->
-                    <service-call name="create#mantle.account.invoice.InvoiceItem" out-map="iiOut"
+                    <service-call name="create#mantle.account.invoice.InvoiceItem"
                             in-map="[invoiceId:invoiceId, invoiceItemSeqId:orderItem.orderItemSeqId,
                                 parentItemSeqId:orderItem.parentItemSeqId, itemTypeEnumId:orderItem.itemTypeEnumId ?: 'ItemSales',
                                 amount:orderItem.unitAmount, description:orderItem.itemDescription, quantity:quantityNotBilled,
@@ -822,7 +822,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <iterate list="shipmentItemSourceList" entry="shipmentItemSource">
                         <if condition="!shipmentItemSource.invoiceId &amp;&amp; quantityNotShipSourced >= shipmentItemSource.quantity">
                             <set field="shipmentItemSource.invoiceId" from="invoiceId"/>
-                            <set field="shipmentItemSource.invoiceItemSeqId" from="iiOut.invoiceItemSeqId"/>
+                            <set field="shipmentItemSource.invoiceItemSeqId" from="orderItem.invoiceItemSeqId"/>
                             <entity-update value-field="shipmentItemSource"/>
                             <set field="quantityNotShipSourced" from="quantityNotShipSourced - shipmentItemSource.quantity"/>
                             <set field="curShipmentId" from="shipmentItemSource.shipmentId"/>
@@ -832,7 +832,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                     <!-- now create OrderItemBilling with shipmentId if available -->
                     <service-call name="create#mantle.order.OrderItemBilling"
-                            in-map="oibBaseMap + [invoiceId:invoiceId, invoiceItemSeqId:iiOut.invoiceItemSeqId,
+                            in-map="oibBaseMap + [invoiceId:invoiceId, invoiceItemSeqId:orderItem.invoiceItemSeqId,
                                 amount:orderItem.unitAmount, quantity:quantityNotBilled, shipmentId:curShipmentId]"/>
                 </if>
             </iterate>


### PR DESCRIPTION
When creating an invoice using mantle.account.services.InvoiceServices.create#EntireOrderPartInvoice the resulting OrderItemBilling entityValues have no corresponding invoiceItemSeqId.

This happens because when creating the InvoiceItem, the result is stored in a map called iiOut which would contain the primary keys created during the creation of the new entityValue. But in the service call, all primary keys are specified, as invoiceItemSeqId is defined based on the corresponding OrderItem's orderItemSeqId. Therefore, the resulting iiOut map is empty, and when the OrderItemBilling is created, the invoiceItemSeqId is defined based on the iiOut map, so it is created as null.