### PR TITLE
Include assetId when checking for existing AcctgTrans for an AssetDetail value

### DIFF
--- a/service/mantle/ledger/AssetAutoPostServices.xml
+++ b/service/mantle/ledger/AssetAutoPostServices.xml
@@ -735,6 +735,7 @@ along with this software (see the LICENSE.md file). If not, see
 
             <!-- make sure there is no existing transaction -->
             <entity-find entity-name="mantle.ledger.transaction.AcctgTrans" list="existingTransList">
+                <econdition field-name="assetId" from="assetDetail.assetId"/>
                 <econdition field-name="physicalInventoryId" from="assetDetail.physicalInventoryId"/>
                 <econdition field-name="acctgTransTypeEnumId" operator="in" from="['AttInventoryVariance', 'AttAssetVariance']"/>
                 <!-- best to leave reversed/reverse tx in place; on a side note to delete them must to reverse before reversed -->


### PR DESCRIPTION
One PhysicalInventory (PI) can have multiple PhysicalInventoryCounts (PIC), and normally each PIC would refer to a different AssetId. Currently, when two PIC are generated, each referring to a different AssetId with a difference on the QoH, only the first one would get posted, and the second one ignored.
This change adds a condition that, in order to ignore the second posting, it should refer not only to the same PI but also to the same AssetId.
Another point, but not included in this change, is that it seems that when a second PIC changes the same AssetId QoH, the posting should not be ignored but should generate a re-post instead, am I right?