### PR TITLE
Avoid implicitly setting rootWorkEffortId on a project WorkEffort.

### DIFF
--- a/service/mantle/work/ProjectServices.xml
+++ b/service/mantle/work/ProjectServices.xml
@@ -114,7 +114,8 @@ along with this software (see the LICENSE.md file). If not, see
     <service verb="update" noun="Project">
         <in-parameters>
             <parameter name="workEffortId" required="true"/>
-            <auto-parameters entity-name="mantle.work.effort.WorkEffort" include="nonpk"/>
+            <auto-parameters entity-name="mantle.work.effort.WorkEffort" include="nonpk">
+                <exclude field-name="rootWorkEffortId"/></auto-parameters>
             <parameter name="estimatedStartDate" type="Timestamp" format="yyyy-MM-dd"/>
             <parameter name="estimatedCompletionDate" type="Timestamp" format="yyyy-MM-dd"/>
 


### PR DESCRIPTION
This is one possible fix for https://moqui.org/apps/hm/Task/TaskSummary?workEffortId=MBA-100000

Normally, a project does not have a rootWorkEffortId, so we should not include it as a parameter and thus avoid setting it in the database.