### PR TITLE
Fix calculation of project times.

### DIFF
--- a/entity/WorkEffortViewEntities.xml
+++ b/entity/WorkEffortViewEntities.xml
@@ -498,6 +498,7 @@ along with this software (see the LICENSE.md file). If not, see
     <view-entity entity-name="TaskTimeSummary" package="mantle.work.time">
         <member-entity entity-alias="WEFF" entity-name="mantle.work.effort.WorkEffort"/>
         <alias entity-alias="WEFF" name="rootWorkEffortId"/>
+        <alias entity-alias="WEFF" name="workEffortTypeEnumId"/>
         <alias entity-alias="WEFF" name="estimatedWorkTime" function="sum"/>
         <alias entity-alias="WEFF" name="actualWorkTime" function="sum"/>
         <alias entity-alias="WEFF" name="remainingWorkTime" function="sum"/>

--- a/service/mantle/work/TaskServices.xml
+++ b/service/mantle/work/TaskServices.xml
@@ -311,7 +311,8 @@ along with this software (see the LICENSE.md file). If not, see
         <in-parameters><parameter name="rootWorkEffortId" required="true"/></in-parameters>
         <actions>
             <entity-find entity-name="mantle.work.time.TaskTimeSummary" list="ttsList">
-                <econdition field-name="rootWorkEffortId"/></entity-find>
+                <econdition field-name="rootWorkEffortId"/>
+                <econdition field-name="workEffortTypeEnumId" value="WetTask"/></entity-find>
             <if condition="ttsList">
                 <entity-find-one entity-name="mantle.work.effort.WorkEffort" value-field="rootWorkEffort">
                     <field-map field-name="workEffortId" from="rootWorkEffortId"/>


### PR DESCRIPTION
This pull request fixes https://moqui.org/apps/hm/Task/TaskSummary?workEffortId=MBA-100000

Even if a project has its own workEffortId set as rootWorkEffortId, with this change it will not be included when adding the hours for each task workEffort.