### PR TITLE
Fix InvoiceProductStores returning for lack of order

### DIFF
--- a/service/mantle/account/InvoiceServices.xml
+++ b/service/mantle/account/InvoiceServices.xml
@@ -2064,7 +2064,6 @@ along with this software (see the LICENSE.md file). If not, see
                 <select-field field-name="orderId"/>
             </entity-find>
             <set field="orderIdSet" from="new HashSet(orderItemBillingList*.orderId)"/>
-            <if condition="!orderIdSet"><return/></if>
 
             <entity-find entity-name="mantle.order.OrderHeader" list="orderHeaderList" distinct="true">
                 <econdition field-name="orderId" operator="in" from="orderIdSet"/>


### PR DESCRIPTION
`send#InvoiceStoreEmail` calls `find#InvoiceProductStores` to determine which store should be used to find the email template. `InvoiceProductStores` has code to find the product store using a party setting, but it can never be reached if there is not an order for the invoice.