### PR TITLE
Added statusId as a condition for assets when updating inventory. If …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,7 +48,7 @@ Written in 2017 by Oleg Andrieiev - onadreyev
 Written in 2017 by Zhen Zhao Wei - WillWei1983
 Written in 2017 by Zhang Wei - zhangwei1979
 written in 2018 by Hans Bakker - hansbak
-
+written in 2019 by Daniel Taylor - danieltaylor-nz
 
 ===========================================================================
 
@@ -83,4 +83,4 @@ Written in 2017 by Oleg Andrieiev - onadreyev
 Written in 2017 by Zhen Zhao Wei - WillWei1983
 Written in 2017 by Zhang Wei - zhangwei1979
 written in 2018 by Hans Bakker - hansbak
-
+written in 2019 by Daniel Taylor - danieltaylor-nz

--- a/service/mantle/product/AssetServices.xml
+++ b/service/mantle/product/AssetServices.xml
@@ -2136,6 +2136,7 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="currentQoh" from="0"/>
             <entity-find entity-name="mantle.product.asset.Asset" list="assetList">
                 <econdition field-name="productId"/><econdition field-name="facilityId"/>
+                <econdition field-name="statusId" ignore-if-empty="true"/>
                 <econdition field-name="quantityOnHandTotal" operator="not-equals" from="0"/>
                 <econdition field-name="locationSeqId" ignore-if-empty="true"/>
                 <econdition field-name="lotId" ignore-if-empty="true"/>


### PR DESCRIPTION
…passed, only assets with the matching status will be updated

I have assets in Defective or Deactivated status, and when calling this service with inbound asset in 'Available' status, the defective assets are having their QOHT being updated. 

This change means that while calling record#PhysicalInventoryQuantity, you can pass the status of your Inventory, and the relevant Assets will be updated/created.

I tested this by setting Assets to various statuses and then receiving inventory in same or different statuses. 
