### PR TITLE
L10n

### DIFF
--- a/data/OrderInstallData.xml
+++ b/data/OrderInstallData.xml
@@ -27,7 +27,25 @@ along with this software (see the LICENSE.md file). If not, see
     <moqui.basic.LocalizedMessage locale="default" original="OrderApprovePaymentAuthorizedLow"
             localized="Total authorized or later payment total ${ec.l10n.formatCurrency(totalAuthorized, orderHeader.currencyUomId)} is less than order total ${ec.l10n.formatCurrency(orderHeader.grandTotal, orderHeader.currencyUomId)}"/>
     <!-- TODO more to do between these in service -->
+    <moqui.basic.LocalizedMessage locale="default" original="OrderApproveStoreManualApprove" localized="==> Store configured to require manual approval"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderApprovePartNoVendor" localized="Part ${orderPart.orderPartSeqId} has no vendor"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderApprovePartNoCustomer" localized="Part ${orderPart.orderPartSeqId} has no customer"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderApproveNewCustomer" localized="Customer ${firstOrderPart.customerPartyId} is a new customer"/>
     <moqui.basic.LocalizedMessage locale="default" original="OrderApproveNearOrder"
             localized="Found similar order ${nearOrder.orderId}:${nearOrder.orderPartSeqId} placed ${ec.l10n.format(nearOrder.placedDate, null)} (${ec.l10n.format(diffHours, '0.0')}h ${isFuture ? 'after' : 'before'}) with ${ec.l10n.format(nearItem.quantity, '0.##')} of product ${nearItem.productId}"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderApproveShippingAddressTrust" localized="Part ${orderPart.orderPartSeqId} shipping address ${postalCm.address1}, ${postalCm.postalCode ?: '-'} has trust level of ${trustLevelEnum.description}"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailPartPaymentIncomplete" localized="Payments total (${ec.l10n.formatCurrency(orderPartInfo.paymentsTotal ?: 0.0, orderHeader?.currencyUomId)}) is less than order part total (${ec.l10n.formatCurrency(orderPartInfo.orderPart.partTotal ?: 0.0, orderHeader?.currencyUomId)})"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlacePartPaymentIncomplete" localized="Part ${orderPart.orderPartSeqId} payments total (${ec.l10n.formatCurrency(paymentsTotal ?: 0.0, (String) orderHeader?.currencyUomId)}) is less than order part total (${ec.l10n.formatCurrency(orderPart.partTotal ?: 0.0, (String) orderHeader?.currencyUomId)})"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlacePartNoVendor" localized="Part ${orderPart.orderPartSeqId} has no vendor"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlacePartNoCustomer" localized="Part ${orderPart.orderPartSeqId} has no customer"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlacePartNoShippingAddress" localized="Part ${orderPart.orderPartSeqId} has no shipping address selected"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlacePartNoShippingMethod" localized="Part ${orderPart.orderPartSeqId} has no shipment method selected"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderPlaceNoItems" localized="Order has no items"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailConfirmCloseOrder" localized="Really close order? If no items shipped the order will be Cancelled. If partially shipped all items will be reduced to shipped quantity and the order will be Completed."/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailItemBilled" localized="Billed:${returnableOut.isProductItemType ? ec.l10n.format(returnableOut.invoiceQuantity, '#,##0.###') : ec.l10n.format(returnableOut.invoiceTotal, '#,##0.00')}"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailItemReturned" localized="Returned:${returnableOut.isProductItemType ? ec.l10n.format(returnableOut.returnedQuantity, '#,##0.###') : ec.l10n.format(returnableOut.returnedTotal, '#,##0.00')}"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailItemReturnable" localized="Returnable:${returnableOut.isProductItemType ? ec.l10n.format(returnableOut.returnableQuantity, '#,##0.###') : ec.l10n.format(returnableOut.returnableTotal, '#,##0.00')}"/>
+    <moqui.basic.LocalizedMessage locale="default" original="OrderDetailConfirmClosePart" localized="Really close order part? If no items shipped the part will be Cancelled. If partially shipped all items will be reduced to shipped quantity and the part will be Completed."/>
+
 
 </entity-facade-xml>

--- a/service/mantle/order/OrderInfoServices.xml
+++ b/service/mantle/order/OrderInfoServices.xml
@@ -168,7 +168,7 @@ along with this software (see the LICENSE.md file). If not, see
 
             <entity-find-related value-field="orderHeader" relationship-name="mantle.order.OrderItem"
                     list="orderItemList" order-by-list="['orderItemSeqId']"/>
-            <if condition="!orderItemList"><script>placeWarnings.add("Order has no items")</script></if>
+            <if condition="!orderItemList"><script>placeWarnings.add(ec.resource.expand('OrderPlaceNoItems', null))</script></if>
             <!-- put items with parentItemSeqId in the list after their parent -->
             <script><![CDATA[
                 orderItemWithChildrenSet = new HashSet()
@@ -356,14 +356,14 @@ along with this software (see the LICENSE.md file). If not, see
                 }
                 BigDecimal partTotalUnpaid = (orderPart.partTotal ?: 0.0) - (paymentsTotal ?: 0.0)
 
-                if (!orderPart.vendorPartyId) placeWarnings.add("Part ${orderPart.orderPartSeqId} has no vendor")
-                if (!orderPart.customerPartyId) placeWarnings.add("Part ${orderPart.orderPartSeqId} has no customer")
+                if (!orderPart.vendorPartyId) placeWarnings.add(ec.resource.expand('OrderPlacePartNoVendor', null, [orderPart:orderPart]))
+                if (!orderPart.customerPartyId) placeWarnings.add(ec.resource.expand('OrderPlacePartNoCustomer', null, [orderPart:orderPart]))
                 if (paymentsTotal < (BigDecimal) orderPart.partTotal)
-                    placeWarnings.add("Part ${orderPart.orderPartSeqId} payments total (${ec.l10n.formatCurrency(paymentsTotal ?: 0.0, (String) orderHeader?.currencyUomId)}) is less than order part total (${ec.l10n.formatCurrency(orderPart.partTotal ?: 0.0, (String) orderHeader?.currencyUomId)})")
+                    placeWarnings.add(ec.resource.expand('OrderPlacePartPaymentIncomplete', null, [orderPart:orderPart]))
                 if (!isCustomerInternalOrg && !orderPart.postalContactMechId)
-                    placeWarnings.add("Part ${orderPart.orderPartSeqId} has no shipping address selected")
+                    placeWarnings.add(ec.resource.expand('OrderPlacePartNoShippingAddress', null, [orderPart:orderPart]))
                 if (!isCustomerInternalOrg && !orderPart.shipmentMethodEnumId)
-                    placeWarnings.add("Part ${orderPart.orderPartSeqId} has no shipment method selected")
+                    placeWarnings.add(ec.resource.expand('OrderPlacePartNoShippingMethod', null, [orderPart:orderPart]))
 
                 List orderItemSeqIdList = partOrderItemList*.orderItemSeqId
                 List partShipmentItemSourceList = []
@@ -548,7 +548,7 @@ along with this software (see the LICENSE.md file). If not, see
         <implements service="mantle.order.OrderInfoServices.validate#Order"/>
         <actions>
             <set field="approveWarnings" from="[]"/>
-            <script>approveWarnings.add("==> Store configured to require manual approval")</script>
+            <script>approveWarnings.add(ec.resource.expand('OrderApproveStoreManualApprove', null))</script>
         </actions>
     </service>
 
@@ -606,11 +606,11 @@ along with this software (see the LICENSE.md file). If not, see
             <set field="noCustomerOrVendor" from="false"/>
             <iterate list="orderPartList" entry="orderPart">
                 <if condition="!orderPart.vendorPartyId">
-                    <script>approveWarnings.add(ec.resource.expand('Part ${orderPart.orderPartSeqId} has no vendor', null))</script>
+                    <script>approveWarnings.add(ec.resource.expand('OrderApprovePartNoVendor', null))</script>
                     <set field="noCustomerOrVendor" from="true"/>
                 </if>
                 <if condition="!orderPart.customerPartyId">
-                    <script>approveWarnings.add(ec.resource.expand('Part ${orderPart.orderPartSeqId} has no customer', null))</script>
+                    <script>approveWarnings.add(ec.resource.expand('OrderApprovePartNoCustomer', null))</script>
                     <set field="noCustomerOrVendor" from="true"/>
                 </if>
             </iterate>
@@ -681,7 +681,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                 <!-- check new customer (no other orders; see also PromotionServices.apply#NewCustomerDiscount) -->
                 <if condition="otherPartCount == 0 &amp;&amp; !'false'.equals(storeSettingList.find({'PsstOrdApproveNewCust'.equals(it.settingTypeEnumId)})?.settingValue)">
-                    <script>approveWarnings.add(ec.resource.expand('Customer ${firstOrderPart.customerPartyId} is a new customer', null))</script>
+                    <script>approveWarnings.add(ec.resource.expand('OrderApproveNewCustomer', null))</script>
                 </if>
 
                 <!-- check shipping address (for each part) present and valid -->
@@ -697,7 +697,7 @@ along with this software (see the LICENSE.md file). If not, see
                         <if condition="!'CmtlValid'.equals(trustLevelEnumId) &amp;&amp; !'CmtlVerified'.equals(trustLevelEnumId)">
                             <entity-find-one entity-name="moqui.basic.Enumeration" value-field="trustLevelEnum">
                                 <field-map field-name="enumId" from="trustLevelEnumId"/></entity-find-one>
-                            <script>approveWarnings.add(ec.resource.expand('Part ${orderPart.orderPartSeqId} shipping address ${postalCm.address1}, ${postalCm.postalCode} has trust level of ${trustLevelEnum.description}', null))</script>
+                            <script>approveWarnings.add(ec.resource.expand('OrderApproveShippingAddressTrust', null))</script>
                         </if>
                     </if>
                 </iterate>

--- a/service/mantle/party/DuplicateServices.xml
+++ b/service/mantle/party/DuplicateServices.xml
@@ -253,7 +253,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="toPartyId"><description>If specified only looks at this part for matches, if not query all addresses</description></parameter>
             <parameter name="address1" required="true"/>
             <parameter name="unitNumber"/>
-            <parameter name="postalCode" required="true"/>
+            <parameter name="postalCode"/>
             <parameter name="postalCodeExt"/>
             <parameter name="countryGeoId"/>
             <parameter name="contactMechPurposeId"><description>Only used if toPartyId specified to limit match by purpose</description></parameter>
@@ -278,7 +278,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <date-filter/><econdition field-name="partyId" from="toPartyId"/>
                     <econdition field-name="address1" operator="like" from="address1" ignore-case="true"/>
                     <econdition field-name="unitNumber" operator="like" from="unitNumber" ignore-if-empty="true"/>
-                    <econdition field-name="postalCode"/>
+                    <econdition field-name="postalCode" or-null="true" ignore-if-empty="true"/>
                     <econdition field-name="postalCodeExt" or-null="true" ignore-if-empty="true"/>
                     <econdition field-name="countryGeoId" or-null="true" ignore-if-empty="true"/>
                     <econdition field-name="contactMechPurposeId" ignore-if-empty="true"/>


### PR DESCRIPTION
Move several messages from mantle/order/OrderInfoServices.xml to localizedMessage records. Allows translation of long messages, cleans up code.
Some messages require to add an extra map ([orderPart:orderPart]) because the variable is defined only in the script and not present in the context.