### PR TITLE
Bug Fix: mantle.account.PaymentMethodServices.expunge#PaymentMethod

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ Written in 2017 by Zhang Wei - zhangwei1979
 written in 2018 by Hans Bakker - hansbak
 written in 2019 by Daniel Taylor - danieltaylor-nz
 written in 2019 by Deepak Dixit - dixitdeepak
+written in 2019 by Arzang Kasiri - akasiri
 
 ===========================================================================
 
@@ -86,3 +87,4 @@ Written in 2017 by Zhang Wei - zhangwei1979
 written in 2018 by Hans Bakker - hansbak
 written in 2019 by Daniel Taylor - danieltaylor-nz
 written in 2019 by Deepak Dixit - dixitdeepak
+written in 2019 by Arzang Kasiri - akasiri

--- a/service/mantle/account/PaymentMethodServices.xml
+++ b/service/mantle/account/PaymentMethodServices.xml
@@ -287,24 +287,33 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <entity-find-one entity-name="mantle.account.method.PaymentMethod" value-field="paymentMethod"/>
 
-            <entity-find entity-name="mantle.account.method.PaymentMethod" list="pmList">
-                <econdition field-name="originalPaymentMethodId" from="paymentMethod.originalPaymentMethodId"/>
-            </entity-find>
+            <if condition="paymentMethod.originalPaymentMethodId != null">
+                <then>
+                    <entity-find entity-name="mantle.account.method.PaymentMethod" list="pmList">
+                        <econdition field-name="originalPaymentMethodId" from="paymentMethod.originalPaymentMethodId"/>
+                    </entity-find>
 
-            <iterate list="pmList" entry="pmValue">
-                <!-- TODO: clear paymentMethodId references for FK error on delete -->
-                <service-call name="delete#mantle.account.method.BankAccount" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
-                <service-call name="delete#mantle.account.method.CreditCard" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
-                <service-call name="delete#mantle.account.method.PaymentMethod" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
-            </iterate>
+                    <iterate list="pmList" entry="pmValue">
+                        <!-- TODO: clear paymentMethodId references for FK error on delete -->
+                        <service-call name="delete#mantle.account.method.BankAccount" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
+                        <service-call name="delete#mantle.account.method.CreditCard" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
+                        <service-call name="delete#mantle.account.method.PaymentMethod" in-map="[paymentMethodId:pmValue.paymentMethodId]"/>
+                    </iterate>
 
-            <!-- if the original record doesn't have originalPaymentMethodId populated it won't have been deleted above -->
-            <entity-find-one entity-name="mantle.account.method.PaymentMethod" value-field="origPm">
-                <field-map field-name="paymentMethodId" from="paymentMethod.originalPaymentMethodId"/></entity-find-one>
-            <if condition="origPm">
-                <service-call name="delete#mantle.account.method.BankAccount" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
-                <service-call name="delete#mantle.account.method.CreditCard" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
-                <service-call name="delete#mantle.account.method.PaymentMethod" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
+                    <!-- if the original record doesn't have originalPaymentMethodId populated it won't have been deleted above -->
+                    <entity-find-one entity-name="mantle.account.method.PaymentMethod" value-field="origPm">
+                        <field-map field-name="paymentMethodId" from="paymentMethod.originalPaymentMethodId"/></entity-find-one>
+                    <if condition="origPm">
+                        <service-call name="delete#mantle.account.method.BankAccount" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
+                        <service-call name="delete#mantle.account.method.CreditCard" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
+                        <service-call name="delete#mantle.account.method.PaymentMethod" in-map="[paymentMethodId:origPm.paymentMethodId]"/>
+                    </if>
+                </then>
+                <else>
+                    <service-call name="delete#mantle.account.method.BankAccount" in-map="[paymentMethodId:paymentMethodId]"/>
+                    <service-call name="delete#mantle.account.method.CreditCard" in-map="[paymentMethodId:paymentMethodId]"/>
+                    <service-call name="delete#mantle.account.method.PaymentMethod" in-map="[paymentMethodId:paymentMethodId]"/>
+                </else>
             </if>
         </actions>
     </service>


### PR DESCRIPTION
expunge#PaymentMethod deletes all PaymentMethods with originalPaymentMethodId == null when the given PaymentMethod's originalPaymentMethodId is null. I've changed the service to only search for and delete previous payment methods if the given PaymentMethod's originalPaymentMethodId != null. If it is null, the service runs the delete process on just the given PaymentMethod.