### PR TITLE
Added a null check to the asset summary list to prevent an error when…

### DIFF
--- a/service/mantle/product/AssetServices.xml
+++ b/service/mantle/product/AssetServices.xml
@@ -124,7 +124,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="statusId" value="AstAvailable"/>
                     <select-field field-name="availableToPromiseTotal"/>
                 </entity-find>
-                <if condition="quantSumList.size() &gt; 0">
+                <if condition="quantSumList.size() &gt; 0 &amp;&amp; quantSumList[0].availableToPromiseTotal">
                     <set field="availableToPromiseTotal" from="availableToPromiseTotal + quantSumList[0].availableToPromiseTotal"/></if>
             </iterate>
         </actions>


### PR DESCRIPTION
… the product cannot be found in the facilities.  Thanks to James for raising the bug.