### PR TITLE
Fix update cancelled quantity

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,6 +52,7 @@ written in 2019 by Daniel Taylor - danieltaylor-nz
 written in 2019 by Deepak Dixit - dixitdeepak
 written in 2019 by Arzang Kasiri - akasiri
 Written in 2019 by Lawrence Tran - lawrencetran
+written in 2019 by Irwing Herrera - iaha
 
 ===========================================================================
 
@@ -90,3 +91,4 @@ written in 2019 by Daniel Taylor - danieltaylor-nz
 written in 2019 by Deepak Dixit - dixitdeepak
 written in 2019 by Arzang Kasiri - akasiri
 Written in 2019 by Lawrence Tran - lawrencetran
+written in 2019 by Irwing Herrera - iaha

--- a/service/mantle/order/OrderServices.xml
+++ b/service/mantle/order/OrderServices.xml
@@ -1436,7 +1436,8 @@ General Order Placement and eCommerce Usage
 
             <!-- update the OrderItem -->
             <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
-                        orderItemSeqId:orderItem.orderItemSeqId, quantityCancelled:(orderItem.quantityCancelled ? orderItem.quantityCancelled + quantityCancelled : quantityCancelled),
+                        orderItemSeqId:orderItem.orderItemSeqId,
+                        quantityCancelled:(quantityCancelled + (orderItem.quantityCancelled ?: 0)),
                         quantity:(itemQuantity - quantityCancelled)]"/>
 
             <!-- adjust child items (usually discount and tax) for new quantity -->
@@ -1454,7 +1455,8 @@ General Order Placement and eCommerce Usage
                 <if condition="childOrderItem.quantity == itemQuantity"><then>
                     <!-- if child qty == parent qty no need to prorate, just adjust quantities to match -->
                     <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
-                        orderItemSeqId:childOrderItem.orderItemSeqId, quantityCancelled:(childOrderItem.quantityCancelled ? childOrderItem.quantityCancelled + quantityCancelled : quantityCancelled),
+                        orderItemSeqId:childOrderItem.orderItemSeqId,
+                        quantityCancelled:(quantityCancelled + (childOrderItem.quantityCancelled ?: 0)),
                         quantity:(itemQuantity - quantityCancelled)]"/>
                 </then><else>
                     <!-- quantity doesn't match, leave quantity alone and prorate unitAmount -->

--- a/service/mantle/order/OrderServices.xml
+++ b/service/mantle/order/OrderServices.xml
@@ -1436,7 +1436,7 @@ General Order Placement and eCommerce Usage
 
             <!-- update the OrderItem -->
             <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
-                        orderItemSeqId:orderItem.orderItemSeqId, quantityCancelled:quantityCancelled,
+                        orderItemSeqId:orderItem.orderItemSeqId, quantityCancelled:(orderItem.quantityCancelled ? orderItem.quantityCancelled + quantityCancelled : quantityCancelled),
                         quantity:(itemQuantity - quantityCancelled)]"/>
 
             <!-- adjust child items (usually discount and tax) for new quantity -->
@@ -1454,7 +1454,7 @@ General Order Placement and eCommerce Usage
                 <if condition="childOrderItem.quantity == itemQuantity"><then>
                     <!-- if child qty == parent qty no need to prorate, just adjust quantities to match -->
                     <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
-                        orderItemSeqId:childOrderItem.orderItemSeqId, quantityCancelled:quantityCancelled,
+                        orderItemSeqId:childOrderItem.orderItemSeqId, quantityCancelled:(childOrderItem.quantityCancelled ? childOrderItem.quantityCancelled + quantityCancelled : quantityCancelled),
                         quantity:(itemQuantity - quantityCancelled)]"/>
                 </then><else>
                     <!-- quantity doesn't match, leave quantity alone and prorate unitAmount -->


### PR DESCRIPTION
We had an issue today where we noticed that if the cancel#OrderItem was called twice, the quantityCancelled was not summed in the second call. Instead, it was updated with the newly passed in cancelled quantity. 