### PR TITLE
Fixed: The UserAccount should be created if emailAddress is available

### DIFF
--- a/service/mantle/party/PartyServices.xml
+++ b/service/mantle/party/PartyServices.xml
@@ -656,7 +656,7 @@ along with this software (see the LICENSE.md file). If not, see
                         relationshipTypeEnumId:'PrtContact', fromPartyId:partyId, toPartyId:accountPartyId,
                         fromRoleTypeId:'Contact', toRoleTypeId:'Account']"/>
             </if>
-            <if condition="emailAddress &amp;&amp; newPassword">
+            <if condition="emailAddress">
                 <service-call name="mantle.party.PartyServices.create#PartyUserAccount" in-map="context" out-map="context"/>
             </if>
         </actions>


### PR DESCRIPTION
As mentioned in the IN parameter definition of create#PersonCustomer service, if newPassword field is empty, the UserAccount will be created and after this user will have to change or reset.

But with the exiting newPassword check, it was blocking the creation of UserAccount, thus removed the additional check of newPassword.