### PR TITLE
Fix incorrect read of vendorPartyId and customerPartyId for add#OrderProductQuantity

### DIFF
--- a/service/mantle/order/OrderServices.xml
+++ b/service/mantle/order/OrderServices.xml
@@ -628,13 +628,13 @@ General Order Placement and eCommerce Usage
             <!-- look up otherPartyProductId if not specified - first from ProductParty then ProductPrice -->
             <if condition="!otherPartyProductId &amp;&amp; productId">
                 <entity-find-one entity-name="mantle.party.PartyRole" value-field="vendorOrgRole">
-                    <field-map field-name="partyId" from="orderPart.vendorPartyId"/>
+                    <field-map field-name="partyId" from="vendorPartyId"/>
                     <field-map field-name="roleTypeId" value="OrgInternal"/>
                 </entity-find-one>
-                <if condition="vendorOrgRole != null &amp;&amp; orderPart.customerPartyId"><then>
+                <if condition="vendorOrgRole != null &amp;&amp; customerPartyId"><then>
                     <entity-find entity-name="mantle.product.ProductParty" list="otherPartyItemIdList" cache="false">
                         <date-filter/><econdition field-name="productId"/>
-                        <econdition field-name="partyId" from="orderPart.customerPartyId"/>
+                        <econdition field-name="partyId" from="customerPartyId"/>
                         <econdition field-name="roleTypeId" value="Customer"/>
                         <econdition field-name="otherPartyItemId" operator="is-not-null"/>
                     </entity-find>
@@ -644,13 +644,13 @@ General Order Placement and eCommerce Usage
                         <!-- NOTE: consider removing this, ProductParty a better place, but would not be backward compatible -->
                         <entity-find entity-name="mantle.product.ProductPrice" list="otherPartyItemIdList" cache="false">
                             <date-filter/><econdition field-name="productId"/>
-                            <econdition field-name="customerPartyId" from="orderPart.customerPartyId"/>
+                            <econdition field-name="customerPartyId" from="customerPartyId"/>
                             <econdition field-name="otherPartyItemId" operator="is-not-null"/>
                         </entity-find>
                         <if condition="otherPartyItemIdList">
                             <set field="otherPartyProductId" from="otherPartyItemIdList[0].otherPartyItemId"/></if>
                     </else></if>
-                </then><else-if condition="vendorOrgRole == null &amp;&amp; orderPart.vendorPartyId">
+                </then><else-if condition="vendorOrgRole == null &amp;&amp; vendorPartyId">
                     <entity-find entity-name="mantle.product.ProductParty" list="otherPartyItemIdList" cache="false">
                         <date-filter/><econdition field-name="productId"/>
                         <econdition field-name="partyId" from="orderPart.vendorPartyId"/>
@@ -663,7 +663,7 @@ General Order Placement and eCommerce Usage
                         <!-- NOTE: consider removing this, ProductParty a better place, but would not be backward compatible -->
                         <entity-find entity-name="mantle.product.ProductPrice" list="otherPartyItemIdList" cache="false">
                             <date-filter/><econdition field-name="productId"/>
-                            <econdition field-name="vendorPartyId" from="orderPart.vendorPartyId"/>
+                            <econdition field-name="vendorPartyId" from="vendorPartyId"/>
                             <econdition field-name="otherPartyItemId" operator="is-not-null"/>
                         </entity-find>
                         <if condition="otherPartyItemIdList">


### PR DESCRIPTION
customerPartyId set from orderPart.customerPartyId and not found set the current user party id.
Same pattern in case of vendorPartyId, set it from orderPart.vendorPartyId if not found set it from productStore?.organizationPartyId.

But at some places we are reading them form orderPart itself, this give some time can not read property on null object.