### PR TITLE
Added a primary address to Zizi Retail

### DIFF
--- a/data/ZbaOrganizationDemoData.xml
+++ b/data/ZbaOrganizationDemoData.xml
@@ -246,6 +246,7 @@ along with this software (see the LICENSE.md file). If not, see
                     city="Orem" stateProvinceGeoId="USA_UT" countryGeoId="USA" postalCode="84057" postalCodeExt="4605"/>
             <mantle.party.contact.PartyContactMech contactMechPurposeId="PostalPayment" fromDate="1265184000000"/>
             <mantle.party.contact.PartyContactMech contactMechPurposeId="PostalBilling" fromDate="1265184000000"/>
+            <mantle.party.contact.PartyContactMech contactMechPurposeId="PostalPrimary" fromDate="1265184000000"/>
         </mantle.party.contact.ContactMech>
         <mantle.party.contact.ContactMech contactMechId="ORG_ZIZI_RTL_SA" contactMechTypeEnumId="CmtPostalAddress">
             <mantle.party.contact.PostalAddress toName="Ziziwork Retail &amp; Wholesale"


### PR DESCRIPTION
Added a primary address, because without it, the service ContactServices.get#PartyContactInfo returns nothing on demo data.