### PR TITLE
Fixed OrderItemSalesSummary and OrderItemShipBillSummary reports

### DIFF
--- a/entity/OrderViewEntities.xml
+++ b/entity/OrderViewEntities.xml
@@ -312,6 +312,7 @@ along with this software (see the LICENSE.md file). If not, see
         <alias entity-alias="PROD" name="amountUomId"/>
         <alias entity-alias="PROD" name="amountFixed"/>
         <alias entity-alias="PROD" name="productTypeEnumId"/>
+        <alias entity-alias="PROD" name="ownerPartyId"/>
         <alias entity-alias="OITM" name="orderId"/><!-- for a summary report this shouldn't be selected -->
         <alias entity-alias="OITM" name="productId"/>
         <alias entity-alias="OITM" name="itemTypeEnumId"/>
@@ -329,6 +330,7 @@ along with this software (see the LICENSE.md file). If not, see
         <alias name="vendorRoleTypeId" entity-alias="VNDRL" field="roleTypeId"/>
         <alias name="partStatusId" entity-alias="OPRT" field="statusId"/>
         <alias name="vendorPartyId" entity-alias="OPRT"/>
+        <alias name="customerPartyId" entity-alias="OPRT"/>
         <alias name="orderStatusId" entity-alias="OHDR" field="statusId"/>
         <alias name="placedDate" entity-alias="OHDR"/>
         <alias name="productStoreId" entity-alias="OHDR"/>
@@ -397,7 +399,7 @@ along with this software (see the LICENSE.md file). If not, see
         <alias name="vendorRoleTypeId" entity-alias="VNDRL" field="roleTypeId"/>
         <alias name="pseudoId" entity-alias="PROD"/>
         <alias name="productName" entity-alias="PROD"/>
-
+        <alias name="ownerPartyId" entity-alias="PROD"/>
         <alias name="issuedQuantity" entity-alias="ASI" field="quantity" function="sum"/>
         <alias name="billedQuantity" entity-alias="OIB" field="quantity" function="sum"/>
     </view-entity>


### PR DESCRIPTION
We were having trouble with missing aliases on the reports due to errors like 
```
Error adding authz entity filter MANTLE_ACTIVE_ORG_3 condition: org.moqui.entity.EntityException: Tried to filter on field customerPartyId which is not included in view-entity mantle.order.OrderItemSalesSummary
```

I  fixed 3 missing aliases in this PR