### PR TITLE
Clone order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,7 +40,7 @@ Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2012-2016 by Sam Hamilton - samhamilton
 Written in 2014-2015 by Yao Chunlin - chunlinyao
 Written in 2014-2015 by Abdullah Shaikh - abdullahs
-Written in 2015-2015 by Jens Hardings - jenshp
+Written in 2015-2021 by Jens Hardings - jenshp
 Written in 2015-     by Dony Zulkarnaen - donniexyz
 Written in 2015 by Anton Akhiar - akhiar
 Written in 2016 by Shen Defu - shendepu
@@ -80,7 +80,7 @@ Written in 2010-2020 by David E. Jones - jonesde
 Written in 2021-2021 by D. Michael Jones - acetousk
 Written in 2014-2015 by Solomon Bessire - sbessire
 Written in 2014-2015 by Yao Chunlin - chunlinyao
-Written in 2015-2015 by Jens Hardings - jenshp
+Written in 2015-2021 by Jens Hardings - jenshp
 Written in 2015 by Dony Zulkarnaen - donniexyz
 Written in 2012-2015 by Sam Hamilton - samhamilton
 Written in 2015 by Anton Akhiar - akhiar

--- a/service/mantle/order/OrderServices.xml
+++ b/service/mantle/order/OrderServices.xml
@@ -1866,7 +1866,7 @@ General Order Placement and eCommerce Usage
             <set field="productItemTypes" from="productItemTypeEgms*.enumId"/>
 
             <entity-find entity-name="mantle.order.OrderItem" list="valueList">
-                <econdition field-name="orderId" from="baseOrderId"/></entity-find>
+                <econdition field-name="orderId" from="baseOrderId"/><order-by field-name="orderItemSeqId"/></entity-find>
             <iterate list="valueList" entry="value">
                 <if condition="productItemsOnly &amp;&amp; (!value.productId || !productItemTypes.contains(value.itemTypeEnumId))"><continue/></if>
                 <set field="value.orderId" from="orderId"/>


### PR DESCRIPTION
Fix a rare case where cloning an Order with child items leads to a child being processed before its parent so the parent reference is non-existing and is created as null.