### PR TITLE
Fix re-enabling of a subscription after a long period of it being off.

### DIFF
--- a/service/mantle/product/SubscriptionServices.xml
+++ b/service/mantle/product/SubscriptionServices.xml
@@ -145,6 +145,7 @@ along with this software (see the LICENSE.md file). If not, see
             </entity-find>
             <if condition="fromDate == null">
                 <set field="fromDate" from="existingSubscriptionList?.first?.thruDate ?: nowTimestamp"/></if>
+            <if condition="fromDate &lt; nowTimestamp"><set field="fromDate" from="nowTimestamp"/></if>
             <if condition="!resourceInstanceId &amp;&amp; existingSubscriptionList">
                 <set field="resourceInstanceId" from="existingSubscriptionList[0].resourceInstanceId"/></if>
 


### PR DESCRIPTION
If a user has a monthly auto-renew, but then their card had been denied(because they had closed their card account at the bank), then after several months they decided to re-enable their account, the previous code would find the long-ago Subscription record, and add a subscription on the *end* of that.  But since we are 6 or more months past that, the new subscription was totally 100% in the past; this makes no sense.

This adds a date filter, which then excludes those long-ago records.  Now, we can see that there is no previous subscription that is *active*, and create a new entry.
