### PR TITLE
typing error?

### DIFF
--- a/service/mantle/account/PaymentServices.xml
+++ b/service/mantle/account/PaymentServices.xml
@@ -494,7 +494,7 @@ along with this software (see the LICENSE.md file). If not, see
 
                 <!-- see if associated PaymentMethod has a paymentGatewayConfigId first, override Payment or other settings, override parameter too -->
                 <if condition="paymentMethod?.paymentGatewayConfigId">
-                    <set field="paymentGatewayConfigId" from="toPaymentMethod.paymentGatewayConfigId"/></if>
+                    <set field="paymentGatewayConfigId" from="paymentMethod.paymentGatewayConfigId"/></if>
             </then><else>
                 <!-- incoming payment, get paymentInstrumentEnumId and paymentGatewayConfigId from paymentMethod -->
 


### PR DESCRIPTION
i got this error:

Transaction set rollback only. The rollback was originally caused by: Error running service mantle.account.PaymentServices.set#PaymentAutoInfo (Throwable)
java.lang.NullPointerException: Cannot get property 'paymentGatewayConfigId' on null object
	at mantle_account_PaymentServices_set_PaymentAutoInfo.run(mantle_account_PaymentServices_set_PaymentAutoInfo:39) ~[?:?]

this change fixed it....
regards
Hans