### PR TITLE
Add task comment to avoid null on subject and body fields

### DIFF
--- a/service/mantle/work/TaskServices.xml
+++ b/service/mantle/work/TaskServices.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-This software is in the public domain under CC0 1.0 Universal plus a 
+This software is in the public domain under CC0 1.0 Universal plus a
 Grant of Patent License.
 
 To the extent possible under law, the author(s) have dedicated all
@@ -226,7 +226,7 @@ along with this software (see the LICENSE.md file). If not, see
             <service-call name="create#mantle.party.communication.CommunicationEvent" out-map="context"
                     in-map="[communicationEventTypeId:'Comment', contactMechTypeEnumId:'CmtWebForm', statusId:'CeSent',
                         fromPartyId:ec.user.userAccount.partyId, entryDate:ec.user.nowTimestamp,
-                        contentType:contentType, subject:subject, body:body]"/>
+                        contentType:contentType, subject:subject ?: ' ', body:body ?: ' ']"/>
             <service-call name="create#mantle.work.effort.WorkEffortCommEvent"
                     in-map="[workEffortId:workEffortId, communicationEventId:communicationEventId]"/>
         </actions>


### PR DESCRIPTION
This fixes this happening:
[Screencast from 10-14-2022 12:15:39 PM.webm](https://user-images.githubusercontent.com/29029373/195913946-7bb7ac90-9803-42cc-817b-5e9a315c633b.webm)

And makes it now look like this:
[Screencast from 10-14-2022 12:16:36 PM.webm](https://user-images.githubusercontent.com/29029373/195914101-4e26a26c-19b4-4fe9-b1f2-b04c66b33345.webm)
