### PR TITLE
Fix product contentlist new by location

### DIFF
--- a/service/mantle/product/ProductServices.xml
+++ b/service/mantle/product/ProductServices.xml
@@ -820,6 +820,7 @@ along with this software (see the LICENSE.md file). If not, see
             <auto-parameters entity-name="mantle.product.ProductContent" include="nonpk"/>
             <parameter name="productId" required="true"/>
             <parameter name="contentFile" type="org.apache.commons.fileupload.FileItem"/>
+            <parameter name="contentLocation"/>
             <parameter name="contentText" allow-html="any"/>
             <parameter name="textExtension" default-value="html"/>
             <parameter name="filename"/>
@@ -830,13 +831,15 @@ along with this software (see the LICENSE.md file). If not, see
             <if condition="contentFile != null &amp;&amp; contentFile.size &gt; 0"><then>
                 <service-call name="mantle.product.ProductServices.save#ProductContentFile" in-map="context"/>
             </then><else>
-                <if condition="!contentText"><set field="contentText" value="[placeholder - delete me]"/></if>
-                <if condition="!filename"><set field="filename" value="${productContentTypeEnumId}_${productContentId}.${textExtension ?: 'html'}"/></if>
-                <!-- NOTE: no need to use mantle.content.large.root for this -->
-                <set field="contentRoot" from="ec.user.getPreference('mantle.content.root') ?: 'dbresource://mantle/content'"/>
-                <set field="contentLocation" value="${contentRoot}/product/${productId}/${filename}"/>
-                <set field="docRr" from="ec.resource.getLocationReference(contentLocation)"/>
-                <script>docRr.putText(contentText)</script>
+                <if condition="!contentLocation">
+                    <if condition="!contentText"><set field="contentText" value="[placeholder - delete me]"/></if>
+                    <if condition="!filename"><set field="filename" value="${productContentTypeEnumId}_${productContentId}.${textExtension ?: 'html'}"/></if>
+                    <!-- NOTE: no need to use mantle.content.large.root for this -->
+                    <set field="contentRoot" from="ec.user.getPreference('mantle.content.root') ?: 'dbresource://mantle/content'"/>
+                    <set field="contentLocation" value="${contentRoot}/product/${productId}/${filename}"/>
+                    <set field="docRr" from="ec.resource.getLocationReference(contentLocation)"/>
+                    <script>docRr.putText(contentText)</script>
+                </if>
                 <service-call name="update#mantle.product.ProductContent" in-map="[productContentId:productContentId, contentLocation:contentLocation]"/>
             </else></if>
         </actions>


### PR DESCRIPTION
Add contentLocation parameter to create#ProductContent, so that external callers can create the location through whatever procedure they require.