### PR TITLE
Allow for a variable amount of decimal digits

### DIFF
--- a/service/mantle/account/FinancialAccountServices.xml
+++ b/service/mantle/account/FinancialAccountServices.xml
@@ -227,6 +227,8 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="entryDate" type="Timestamp" default="ec.user.nowTimestamp"/>
             <!-- maybe support in the future with currency conversion: <parameter name="amountUomId"/> -->
             <!-- <parameter name="isRefund" type="Boolean" default="false"/> -->
+            <parameter name="decimalDigits" type="Integer" default="2" required="true">
+                <description>Must be less than or equal to 4 due to that being the limit of currency-amount entity field type</description></parameter>
         </in-parameters>
         <out-parameters>
             <parameter name="amount" type="BigDecimal"/>
@@ -235,7 +237,7 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="finAccountTransId"/>
         </out-parameters>
         <actions>
-            <set field="amount" from="amount.setScale(2, BigDecimal.ROUND_HALF_UP)"/>
+            <set field="amount" from="amount.setScale(decimalDigits, BigDecimal.ROUND_HALF_UP)"/>
             <set field="performedByUserId" from="ec.user.userId"/>
 
             <!-- do a for-update query to lock the FinancialAccount record -->
@@ -267,6 +269,8 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="entryDate" type="Timestamp" default="ec.user.nowTimestamp"/>
             <!-- maybe support in the future with currency conversion: <parameter name="amountUomId"/> -->
             <!-- <parameter name="isRefund" type="Boolean" default="false"/> -->
+            <parameter name="decimalDigits" type="Integer" default="2" required="true">
+                <description>Must be less than or equal to 4 due to that being the limit of currency-amount entity field type</description></parameter>
         </in-parameters>
         <out-parameters>
             <parameter name="amount" type="BigDecimal"/>
@@ -277,7 +281,7 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <if condition="amount &lt; 0.0"><return error="true" message="Cannot deposit negative amount ${amount}, do a withdraw instead"/></if>
 
-            <set field="amount" from="amount.setScale(2, BigDecimal.ROUND_HALF_UP)"/>
+            <set field="amount" from="amount.setScale(decimalDigits, BigDecimal.ROUND_HALF_UP)"/>
             <set field="performedByUserId" from="ec.user.userId"/>
 
             <!-- do a for-update query to lock the FinancialAccount record -->
@@ -310,6 +314,8 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="entryDate" type="Timestamp" default="ec.user.nowTimestamp"/>
             <!-- maybe support in the future with currency conversion: <parameter name="amountUomId"/> -->
             <!-- <parameter name="isRefund" type="Boolean" default="false"/> -->
+            <parameter name="decimalDigits" type="Integer" default="2" required="true">
+                <description>Must be less than or equal to 4 due to that being the limit of currency-amount entity field type</description></parameter>
         </in-parameters>
         <out-parameters>
             <parameter name="amount" type="BigDecimal"/>
@@ -322,7 +328,7 @@ along with this software (see the LICENSE.md file). If not, see
         <actions>
             <if condition="amount &lt; 0.0"><return error="true" message="Cannot withdraw negative amount ${amount}, do a deposit instead"/></if>
 
-            <set field="amount" from="amount.setScale(2, BigDecimal.ROUND_HALF_UP)"/>
+            <set field="amount" from="amount.setScale(decimalDigits, BigDecimal.ROUND_HALF_UP)"/>
             <set field="performedByUserId" from="ec.user.userId"/>
 
             <!-- do a for-update query to lock the FinancialAccount record -->


### PR DESCRIPTION
Because different currencies have different values, different decimal digits are needed for different financial accounts.

This is backwards compatible