### PR TITLE
Return shipmentPackageSeqId parameter in add#ItemToPackage service

### DIFF
--- a/service/mantle/shipment/ShipmentServices.xml
+++ b/service/mantle/shipment/ShipmentServices.xml
@@ -371,6 +371,9 @@ along with this software (see the LICENSE.md file). If not, see
             <parameter name="shipmentPackageSeqId"><description>If not specified will be put in a new package</description></parameter>
             <parameter name="quantity" type="BigDecimal"/>
         </in-parameters>
+        <out-parameters>
+            <parameter name="shipmentPackageSeqId"/>
+        </out-parameters>
         <actions>
             <entity-find-one entity-name="mantle.shipment.ShipmentItem" value-field="shipmentItem">
                 <field-map field-name="shipmentId"/><field-map field-name="productId"/></entity-find-one>


### PR DESCRIPTION
If this service creates a package (line 388), return the shipmentPackageSeqId parameter created there so that future services don't have to add additional lookup queries. It's also just a good practices to return the ids of the entities created.