### PR TITLE
Add rejection services based on cancel services

### DIFF
--- a/service/mantle/order/OrderServices.xml
+++ b/service/mantle/order/OrderServices.xml
@@ -1495,6 +1495,34 @@ General Order Placement and eCommerce Usage
             </else-if></if>
         </actions>
     </service>
+    <service verb="checkRejectedComplete" noun="Order">
+        <in-parameters><parameter name="orderId"/></in-parameters>
+        <out-parameters><parameter name="oldStatusId"/><parameter name="statusChanged" type="Boolean"/></out-parameters>
+        <actions>
+            <!-- if all parts Rejected set header Rejected, if any Completed and all others Completed or Rejected set header Completed -->
+            <set field="statusChanged" from="false"/>
+            <entity-find entity-name="mantle.order.OrderPart" list="orderPartList"><econdition field-name="orderId"/></entity-find>
+            <set field="allRejected" from="true"/>
+            <set field="anyCompleted" from="false"/>
+            <set field="allRejectedOrCompleted" from="true"/>
+            <iterate list="orderPartList" entry="curOrderPart">
+                <if condition="curOrderPart.statusId in ['OrderRejected', 'OrderCancelled']"><continue/></if>
+                <if condition="curOrderPart.statusId == 'OrderCompleted'">
+                    <set field="allRejected" from="false"/>
+                    <set field="anyCompleted" from="true"/>
+                    <continue/>
+                </if>
+                <set field="allRejected" from="false"/>
+                <set field="allRejectedOrCompleted" from="false"/>
+            </iterate>
+            <if condition="allRejected"><then>
+                <service-call name="update#mantle.order.OrderHeader" out-map="context" in-map="[orderId:orderId, statusId:'OrderRejected']"/>
+            </then><else-if condition="anyCompleted &amp;&amp; allRejectedOrCompleted">
+                <service-call name="update#mantle.order.OrderHeader" out-map="context" in-map="[orderId:orderId, statusId:'OrderCompleted']"/>
+            </else-if></if>
+        </actions>
+    </service>
+
 
     <service verb="complete" noun="OrderPart">
         <in-parameters>
@@ -1532,7 +1560,7 @@ General Order Placement and eCommerce Usage
         <description>Call when customer cancels the order. If no items shipped the order will be Cancelled.
             If partially shipped all items will be reduced to shipped quantity and the order will be Completed.</description>
         <implements service="mantle.order.OrderServices.change#OrderStatusInterface"/>
-        <!-- TODO add reject parameter to use OrderRejected status instead of OrderCancelled -->
+        <!-- Note: If using you need to Reject the Order use the reject#Order services. -->
         <actions>
             <!-- does partial cancel if already partially shipped, and then set what is left as completed; otherwise does a full cancel -->
             <entity-find-one entity-name="mantle.order.OrderHeader" value-field="orderHeader" for-update="true"/>
@@ -1771,6 +1799,261 @@ General Order Placement and eCommerce Usage
                         <!-- otherwise call checkComplete#OrderPart -->
                         <service-call name="mantle.order.OrderServices.checkComplete#OrderPart" out-map="checkPartOut"
                                       in-map="[orderId:orderId, orderPartSeqId:orderItem.orderPartSeqId]"/>
+                        <if condition="checkPartOut.statusChanged">
+                            <!-- if all parts Cancelled set header Cancelled, if any Completed and all others Completed or Cancelled set header Completed -->
+                            <service-call name="mantle.order.OrderServices.checkCancelComplete#Order" in-map="[orderId:orderId]"/>
+                        </if>
+                    </else></if>
+                </if>
+            </then><else>
+                <!-- reduce OrderItem Reservations by quantityCancelled? no need to, AssetReservation ECA rule will pick it up -->
+            </else></if>
+        </actions>
+    </service>
+
+    <service verb="reject" noun="Order">
+        <!-- Copied from cancel#Order -->
+        <description>Call when vendor rejects the order. If no items shipped the order will be Rejected.
+            If partially shipped all items will be reduced to shipped quantity and the order will be Rejected.</description>
+        <implements service="mantle.order.OrderServices.change#OrderStatusInterface"/>
+        <actions>
+            <!-- does partial cancel if already partially shipped, and then set what is left as completed; otherwise does a full cancel -->
+            <entity-find-one entity-name="mantle.order.OrderHeader" value-field="orderHeader" for-update="true"/>
+            <if condition="orderHeader == null"><return error="true" message="Order ${orderId} not found"/></if>
+            <if condition="orderHeader.statusId == 'OrderCompleted'"><return error="true" message="Cannot reject order ${orderId}, already Completed"/></if>
+            <if condition="orderHeader.statusId in ['OrderRejected', 'OrderCancelled']">
+                <return message="Order ${orderId} already Cancelled"/></if>
+
+            <!-- cancel item quantities not issued, update or remove ShipmentItemSource records, remove asset reservations if any -->
+            <entity-find entity-name="mantle.product.issuance.AssetIssuance" list="fullAssetIssuanceList">
+                <econdition field-name="orderId"/></entity-find>
+            <entity-find entity-name="mantle.shipment.ShipmentItemSource" list="fullShipmentItemSourceList">
+                <econdition field-name="orderId"/></entity-find>
+
+            <set field="quantityIssued" from="0.0"/>
+            <iterate list="fullAssetIssuanceList" entry="assetIssuance">
+                <set field="quantityIssued" from="quantityIssued + assetIssuance.quantity"/></iterate>
+            <set field="hasIssuedQuantity" from="quantityIssued &gt; 0.0"/>
+
+            <entity-find entity-name="mantle.order.OrderItem" list="orderItemList">
+                <econdition field-name="orderId"/></entity-find>
+            <iterate list="orderItemList" entry="orderItem">
+                <service-call name="mantle.order.OrderServices.reject#OrderItem" out-map="itemOut" out-map-add-to-existing="false"
+                        in-map="[orderId:orderId, orderItemSeqId:orderItem.orderItemSeqId, orderItem:orderItem, checkRejectedPart:false,
+                            fullAssetIssuanceList:fullAssetIssuanceList, fullShipmentItemSourceList:fullShipmentItemSourceList]"/>
+            </iterate>
+
+            <!-- cancel or complete order parts -->
+            <set field="targetStatusId" from="hasIssuedQuantity ? 'OrderCompleted' : 'OrderRejected'"/>
+            <entity-find entity-name="mantle.order.OrderPart" list="orderPartList"><econdition field-name="orderId"/></entity-find>
+            <iterate list="orderPartList" entry="orderPart">
+                <service-call name="update#mantle.order.OrderPart" out-map="context"
+                        in-map="[orderId:orderId, orderPartSeqId:orderPart.orderPartSeqId, statusId:targetStatusId]"/>
+            </iterate>
+
+            <!-- cancel or complete order header -->
+            <service-call name="update#mantle.order.OrderHeader" out-map="context"
+                    in-map="[orderId:orderId, statusId:targetStatusId]"/>
+        </actions>
+    </service>
+    <service verb="reject" noun="OrderPart">
+        <in-parameters>
+            <parameter name="orderId" required="true"/>
+            <parameter name="orderPartSeqId" required="true"/>
+        </in-parameters>
+        <actions>
+            <entity-find-one entity-name="mantle.order.OrderPart" value-field="orderPart" for-update="true"/>
+            <if condition="orderPart == null"><return error="true" message="Order Part ${orderId}:${orderPartSeqId} not found"/></if>
+            <if condition="orderPart.statusId == 'OrderRejected'">
+                <return error="true" message="Cannot reject Order Part ${orderId}:${orderPartSeqId}, already Completed"/></if>
+            <if condition="orderPart.statusId in ['OrderRejected', 'OrderCancelled']">
+                <return message="Order Part ${orderId}:${orderPartSeqId} already Rejected or Cancelled"/></if>
+
+            <set field="hasIssuedQuantity" from="false"/>
+            <entity-find entity-name="mantle.order.OrderItem" list="orderItemList">
+                <econdition field-name="orderId"/><econdition field-name="orderPartSeqId"/></entity-find>
+            <iterate list="orderItemList" entry="orderItem">
+                <service-call name="mantle.order.OrderServices.reject#OrderItem" out-map="itemOut" out-map-add-to-existing="false"
+                        in-map="[orderId:orderId, orderItemSeqId:orderItem.orderItemSeqId, orderItem:orderItem, checkRejectedPart:false]"/>
+                <if condition="itemOut.hasIssuedQuantity"><set field="hasIssuedQuantity" from="true"/></if>
+            </iterate>
+
+            <!-- cancel or complete order part -->
+            <set field="targetStatusId" from="hasIssuedQuantity ? 'OrderCompleted' : 'OrderRejected'"/>
+            <service-call name="update#mantle.order.OrderPart" out-map="context"
+                    in-map="[orderId:orderId, orderPartSeqId:orderPartSeqId, statusId:targetStatusId]"/>
+
+            <!-- if all parts Rejected set header Rejected, if any Completed and all others Completed or Rejected set header Completed -->
+            <service-call name="mantle.order.OrderServices.checkRejectedComplete#Order" in-map="[orderId:orderId]"/>
+        </actions>
+    </service>
+    <service verb="reject" noun="OrderItem" no-tx-cache="true">
+        <in-parameters>
+            <parameter name="orderId" required="true"/>
+            <parameter name="orderItemSeqId" required="true"/>
+            <parameter name="cancelQuantity" type="BigDecimal">
+                <description>Defaults to quantity not yet issued, if greater than quantity not issued will be reduced to quantity not issued</description></parameter>
+            <parameter name="orderItem" type="EntityValue"/>
+            <parameter name="fullAssetIssuanceList" type="List"><parameter name="assetIssuance" type="EntityValue"/></parameter>
+            <parameter name="fullShipmentItemSourceList" type="List"><parameter name="shipmentItemSource" type="EntityValue"/></parameter>
+            <parameter name="checkRejectedPart" type="Boolean" default="true"/>
+        </in-parameters>
+        <out-parameters>
+            <parameter name="hasIssuedQuantity" type="Boolean"/>
+            <parameter name="quantityCancelled" type="BigDecimal"/>
+        </out-parameters>
+        <actions>
+            <if condition="orderItem == null"><entity-find-one entity-name="mantle.order.OrderItem" value-field="orderItem"/></if>
+            <if condition="orderItem == null"><return error="true" message="Order Item ${orderId}:${orderItemSeqId} not found"/></if>
+
+            <!-- only do this for product items -->
+            <if condition="!orderItem.productId"><return/></if>
+            <entity-find entity-name="moqui.basic.EnumGroupMember" list="productItemTypeEgms" cache="true">
+                <econdition field-name="enumGroupEnumId" value="EngItemsProduct"/></entity-find>
+            <set field="productItemTypes" from="productItemTypeEgms*.enumId"/>
+            <if condition="!productItemTypes.contains(orderItem.itemTypeEnumId)">
+                <return type="warning" message="Item ${orderItemSeqId} is not a product type item, not rejecting"/></if>
+
+            <!-- check quantity issued -->
+            <if condition="fullAssetIssuanceList"><then>
+                <filter-map-list list="fullAssetIssuanceList" to-list="itemAssetIssuanceList">
+                    <field-map field-name="orderItemSeqId"/>
+                    <field-map field-name="productId" from="orderItem.productId"/>
+                </filter-map-list>
+            </then><else>
+                <entity-find entity-name="mantle.product.issuance.AssetIssuance" list="itemAssetIssuanceList">
+                    <econdition field-name="orderId"/>
+                    <econdition field-name="orderItemSeqId"/>
+                    <econdition field-name="productId" from="orderItem.productId"/>
+                </entity-find>
+            </else></if>
+
+            <set field="itemQuantityIssued" from="0.0"/>
+            <iterate list="itemAssetIssuanceList" entry="itemAssetIssuance">
+                <set field="itemQuantityIssued" from="itemQuantityIssued + itemAssetIssuance.quantity"/></iterate>
+            <set field="hasIssuedQuantity" from="itemQuantityIssued &gt; 0.0"/>
+
+            <!-- determine quantity to cancel -->
+            <set field="itemQuantity" from="orderItem.quantity != null ? orderItem.quantity : 1.0"/>
+            <set field="notIssuedQuantity" from="itemQuantity - itemQuantityIssued"/>
+            <if condition="notIssuedQuantity &lt; 0.0">
+                <log level="warn" message="In reject#OrderItem itemQuantityIssued ${itemQuantityIssued} is greater than itemQuantity ${itemQuantity}, using 0.0 for notIssuedQuantity instead of ${notIssuedQuantity}"/>
+                <set field="notIssuedQuantity" from="0.0"/>
+            </if>
+            <if condition="cancelQuantity"><then>
+                <if condition="cancelQuantity &gt; notIssuedQuantity"><then>
+                    <set field="quantityCancelled" from="notIssuedQuantity"/>
+                    <message type="warning">Cannot reject quantity ${cancelQuantity}, only ${notIssuedQuantity} not yet shipped for Order Item ${orderId}:${orderItemSeqId}</message>
+                </then><else>
+                    <set field="quantityCancelled" from="cancelQuantity"/>
+                </else></if>
+            </then><else>
+                <set field="quantityCancelled" from="notIssuedQuantity"/>
+            </else></if>
+
+            <if condition="!quantityCancelled"><return/></if>
+
+            <!-- update the OrderItem -->
+            <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
+                        orderItemSeqId:orderItem.orderItemSeqId,
+                        quantityCancelled:(quantityCancelled + (orderItem.quantityCancelled ?: 0)),
+                        quantity:(itemQuantity - quantityCancelled)]"/>
+
+            <!-- adjust child items (usually discount and tax) for new quantity -->
+            <!-- NOTE this is simpler than other prorating because it is only done once, then the item is either completed if partially filled or cancelled otherwise -->
+            <!-- NOTE skip discounts if isPromo=Y? those will be handled by order update triggers, if enabled; maybe best to calc here and disable promo calc (are disabled by default for orders Approved, etc) -->
+            <if condition="itemQuantity == quantityCancelled"><then>
+                <set field="childCancelRatio" from="1.0"/>
+            </then><else>
+                <set field="childCancelRatio" from="(quantityCancelled as BigDecimal).divide(itemQuantity as BigDecimal, 6, BigDecimal.ROUND_HALF_EVEN)"/>
+            </else></if>
+            <set field="childOrderItemList" from="orderItem.'Child#mantle.order.OrderItem'"/>
+            <order-map-list list="childOrderItemList"><order-by field-name="orderItemSeqId"/></order-map-list>
+            <iterate list="childOrderItemList" entry="childOrderItem">
+                <if condition="childOrderItem.quantity == 0.0 || childOrderItem.unitAmount == 0.0"><continue/></if>
+                <if condition="childOrderItem.quantity == itemQuantity"><then>
+                    <!-- if child qty == parent qty no need to prorate, just adjust quantities to match -->
+                    <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
+                        orderItemSeqId:childOrderItem.orderItemSeqId,
+                        quantityCancelled:(quantityCancelled + (childOrderItem.quantityCancelled ?: 0)),
+                        quantity:(itemQuantity - quantityCancelled)]"/>
+                </then><else>
+                    <!-- quantity doesn't match, leave quantity alone and prorate unitAmount -->
+                    <set field="newUnitAmount" from="childOrderItem.unitAmount - ((childCancelRatio as BigDecimal) * (childOrderItem.unitAmount as BigDecimal)).setScale(2, BigDecimal.ROUND_HALF_UP)"/>
+                    <service-call name="update#mantle.order.OrderItem" in-map="[orderId:orderId,
+                        orderItemSeqId:childOrderItem.orderItemSeqId, unitAmount:newUnitAmount]"/>
+                </else></if>
+            </iterate>
+
+            <!-- update or remove ShipmentItemSource records -->
+            <if condition="fullShipmentItemSourceList"><then>
+                <filter-map-list list="fullShipmentItemSourceList" to-list="itemShipmentItemSourceList">
+                    <field-map field-name="orderItemSeqId"/></filter-map-list>
+            </then><else>
+                <entity-find entity-name="mantle.shipment.ShipmentItemSource" list="itemShipmentItemSourceList">
+                    <econdition field-name="orderId"/><econdition field-name="orderItemSeqId"/></entity-find>
+            </else></if>
+
+            <set field="shipmentItemQuantityReducedMap" from="[:]"/>
+            <set field="shipQuantityRemaining" from="quantityCancelled"/>
+            <iterate list="itemShipmentItemSourceList" entry="itemShipmentItemSource">
+                <set field="shipQuantityToReduce" from="shipQuantityRemaining &gt; itemShipmentItemSource.quantityNotHandled ?
+                        itemShipmentItemSource.quantityNotHandled : shipQuantityRemaining"/>
+                <if condition="!shipQuantityToReduce"><continue/></if>
+                <script>addToBigDecimalInMap(itemShipmentItemSource.shipmentId, shipQuantityToReduce, shipmentItemQuantityReducedMap)</script>
+                <!-- reduce quantity by quantityNotHandled -->
+                <service-call name="update#mantle.shipment.ShipmentItemSource"
+                        in-map="[shipmentItemSourceId:itemShipmentItemSource.shipmentItemSourceId, quantityNotHandled:0,
+                                quantity:(itemShipmentItemSource.quantity - shipQuantityToReduce)]"/>
+
+                <set field="shipQuantityRemaining" from="shipQuantityRemaining - shipQuantityToReduce"/>
+            </iterate>
+
+            <iterate list="shipmentItemQuantityReducedMap" entry="shipmentItemQuantityReduced" key="shipmentId">
+                <entity-find-one entity-name="mantle.shipment.ShipmentItem" value-field="shipmentItem">
+                    <field-map field-name="shipmentId"/><field-map field-name="productId" from="orderItem.productId"/></entity-find-one>
+                <if condition="shipmentItem != null">
+                    <set field="newSiQuantity" from="shipmentItem.quantity &gt; shipmentItemQuantityReduced ?
+                                shipmentItem.quantity - shipmentItemQuantityReduced : 0.0"/>
+                    <service-call name="update#mantle.shipment.ShipmentItem"
+                            in-map="[shipmentId:shipmentId, productId:orderItem.productId, quantity:newSiQuantity]"/>
+
+                    <if condition="newSiQuantity == 0.0">
+                        <!-- if no ShipmentItems have quantity greater than 0.0 cancel Shipment -->
+                        <entity-find-count entity-name="mantle.shipment.ShipmentItem" count-field="nonZeroShipItemCount">
+                            <econdition field-name="shipmentId"/>
+                            <econdition field-name="quantity" operator="greater" from="0.0"/>
+                        </entity-find-count>
+                        <if condition="nonZeroShipItemCount == 0">
+                            <!-- cancel#Shipment won't do what it normally does reducing quantities, but just in case other cleanups needed -->
+                            <service-call name="mantle.shipment.ShipmentServices.cancel#Shipment" in-map="[shipmentId:shipmentId]"/>
+                        </if>
+                    </if>
+                </if>
+            </iterate>
+
+            <if condition="quantityCancelled == notIssuedQuantity"><then>
+                <!-- if quantityCancelled == notIssuedQuantity remove all OrderItem Reservations -->
+                <service-call name="mantle.product.AssetServices.remove#OrderItemReservations"
+                        in-map="[orderId:orderId, orderItemSeqId:orderItem.orderItemSeqId]"/>
+
+                <if condition="checkCancelPart &amp;&amp; quantityCancelled == notIssuedQuantity">
+                    <!-- first see if all OrderItem in part have quantity 0, if so cancel order -->
+                    <entity-find-count entity-name="mantle.order.OrderItem" count-field="partItemQtyOverZeroCount">
+                        <econdition field-name="orderId"/>
+                        <econdition field-name="orderPartSeqId" from="orderItem.orderPartSeqId"/>
+                        <econdition field-name="itemTypeEnumId" operator="in" from="productItemTypes"/>
+                        <econdition field-name="quantity" operator="greater" from="0.0"/>
+                    </entity-find-count>
+                    <if condition="partItemQtyOverZeroCount == 0"><then>
+                        <service-call name="update#mantle.order.OrderPart" out-map="context"
+                                in-map="[orderId:orderId, orderPartSeqId:orderItem.orderPartSeqId, statusId:'OrderCancelled']"/>
+                        <!-- if all parts Cancelled set header Cancelled, if any Completed and all others Completed or Cancelled set header Completed -->
+                        <service-call name="mantle.order.OrderServices.checkCancelComplete#Order" in-map="[orderId:orderId]"/>
+                    </then><else>
+                        <!-- otherwise call checkComplete#OrderPart -->
+                        <service-call name="mantle.order.OrderServices.checkComplete#OrderPart" out-map="checkPartOut"
+                                in-map="[orderId:orderId, orderPartSeqId:orderItem.orderPartSeqId]"/>
                         <if condition="checkPartOut.statusChanged">
                             <!-- if all parts Cancelled set header Cancelled, if any Completed and all others Completed or Cancelled set header Completed -->
                             <service-call name="mantle.order.OrderServices.checkCancelComplete#Order" in-map="[orderId:orderId]"/>


### PR DESCRIPTION
For rejection services from a vendor. Instead of complicating the cancel services, just create a copy of them meant for Rejection by vendor.