### PR TITLE
Improve workeffort team support

### DIFF
--- a/entity/RequestViewEntities.xml
+++ b/entity/RequestViewEntities.xml
@@ -46,8 +46,12 @@ along with this software (see the LICENSE.md file). If not, see
         <member-entity entity-alias="REQ" entity-name="mantle.request.Request"/>
         <member-entity entity-alias="RQP" entity-name="mantle.request.RequestParty" join-from-alias="REQ" join-optional="true">
             <key-map field-name="requestId"/></member-entity>
+        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="RQP" join-optional="true">
+            <key-map field-name="partyId" related="toPartyId"/></member-entity>
         <alias-all entity-alias="REQ"/>
         <alias-all entity-alias="RQP"/>
+        <alias-all entity-alias="TPR" prefix="teamRelationship"/>
+        <alias name="teamMemberPartyId" entity-alias="TPR" field="fromPartyId"/>
     </view-entity>
     <view-entity entity-name="RequestPartyAndPerson" package="mantle.request">
         <member-entity entity-alias="RQP" entity-name="mantle.request.RequestParty"/>

--- a/entity/WorkEffortViewEntities.xml
+++ b/entity/WorkEffortViewEntities.xml
@@ -48,12 +48,16 @@ along with this software (see the LICENSE.md file). If not, see
         <member-entity entity-alias="WEFF_ROOT" entity-name="mantle.work.effort.WorkEffort"/>
         <member-entity entity-alias="WEP" entity-name="mantle.work.effort.WorkEffortParty" join-from-alias="WEFF_ROOT">
             <key-map field-name="workEffortId"/></member-entity>
+        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="WEP" join-optional="true">
+            <key-map field-name="partyId" related="toPartyId"/></member-entity>
         <member-entity entity-alias="WEFF" entity-name="mantle.work.effort.WorkEffort" join-from-alias="WEFF_ROOT">
             <key-map field-name="workEffortId" related="rootWorkEffortId"/></member-entity>
         <alias-all entity-alias="WEFF_ROOT" prefix="root"><exclude field="workEffortId"/></alias-all>
         <alias-all entity-alias="WEFF"><exclude field="workTypeEnumId"/></alias-all>
         <alias-all entity-alias="WEP"><exclude field="statusId"/></alias-all>
+        <alias-all entity-alias="TPR" prefix="teamRelationship"/>
         <alias entity-alias="WEP" name="wepStatusId" field="statusId"/>
+        <alias name="teamMemberPartyId" entity-alias="TPR" field="fromPartyId"/>
     </view-entity>
 
     <view-entity entity-name="WorkEffortAndCategoryAppl" package="mantle.work.effort">
@@ -161,9 +165,13 @@ along with this software (see the LICENSE.md file). If not, see
         <member-entity entity-alias="WEFF" entity-name="mantle.work.effort.WorkEffort"/>
         <member-entity entity-alias="WEP" entity-name="mantle.work.effort.WorkEffortParty" join-from-alias="WEFF" join-optional="true">
             <key-map field-name="workEffortId"/></member-entity>
+        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="WEP" join-optional="true">
+            <key-map field-name="partyId" related="toPartyId"/></member-entity>
         <alias-all entity-alias="WEFF"><exclude field="workTypeEnumId"/></alias-all>
         <alias-all entity-alias="WEP"><exclude field="statusId"/></alias-all>
+        <alias-all entity-alias="TPR" prefix="teamRelationship"/>
         <alias name="partyStatusId" entity-alias="WEP" field="statusId"/>
+        <alias name="teamMemberPartyId" entity-alias="TPR" field="fromPartyId"/>
     </view-entity>
     <view-entity entity-name="WorkEffortPartyAndPerson" package="mantle.work.effort">
         <member-entity entity-alias="WEP" entity-name="mantle.work.effort.WorkEffortParty"/>
@@ -212,9 +220,7 @@ along with this software (see the LICENSE.md file). If not, see
         <member-entity entity-alias="WEFF" entity-name="mantle.work.effort.WorkEffort"/>
         <member-entity entity-alias="WEP" entity-name="mantle.work.effort.WorkEffortParty" join-from-alias="WEFF" join-optional="true">
             <key-map field-name="workEffortId"/></member-entity>
-        <member-entity entity-alias="WETP" entity-name="mantle.work.effort.WorkEffortParty" join-from-alias="WEFF" join-optional="true">
-            <key-map field-name="workEffortId"/></member-entity>
-        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="WETP" join-optional="true">
+        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="WEP" join-optional="true">
             <key-map field-name="partyId" related="toPartyId"/></member-entity>
         <member-entity entity-alias="WEFF_ASSOC" entity-name="mantle.work.effort.WorkEffortAssoc" join-from-alias="WEFF" join-optional="true">
             <key-map field-name="workEffortId" related="toWorkEffortId"/></member-entity>
@@ -224,7 +230,7 @@ along with this software (see the LICENSE.md file). If not, see
         <alias-all entity-alias="WEFF"><exclude field="workTypeEnumId"/></alias-all>
         <alias-all entity-alias="WEFF_MLSTN" prefix="milestone"/>
         <alias-all entity-alias="WEP"><exclude field="statusId"/></alias-all>
-        <alias-all entity-alias="WETP" prefix="team"/>
+        <alias-all entity-alias="TPR" prefix="teamRelationship"/>
 
         <alias name="lastUpdatedStamp" entity-alias="WEFF"/>
         <alias name="partyStatusId" entity-alias="WEP" field="statusId"/>

--- a/entity/WorkEffortViewEntities.xml
+++ b/entity/WorkEffortViewEntities.xml
@@ -269,6 +269,8 @@ along with this software (see the LICENSE.md file). If not, see
         <alias name="assetFromDate" entity-alias="WEP" field="fromDate"/>
         <alias name="assetThruDate" entity-alias="WEP" field="thruDate"/>
         <alias name="teamMemberPartyId" entity-alias="TPR" field="fromPartyId"/>
+        <alias name="teamMemberFromDate" entity-alias="TPR" field="fromDate"/>
+        <alias name="teamMemberThruDate" entity-alias="TPR" field="thruDate"/>
         <relationship type="one" title="WorkEffortPurpose" related="moqui.basic.Enumeration">
             <key-map field-name="purposeEnumId"/></relationship>
     </view-entity>

--- a/entity/WorkEffortViewEntities.xml
+++ b/entity/WorkEffortViewEntities.xml
@@ -253,18 +253,22 @@ along with this software (see the LICENSE.md file). If not, see
         <member-entity entity-alias="WEFF" entity-name="mantle.work.effort.WorkEffort"/>
         <member-entity entity-alias="WEP" entity-name="mantle.work.effort.WorkEffortParty" join-from-alias="WEFF" join-optional="true">
             <key-map field-name="workEffortId"/></member-entity>
+        <member-entity entity-alias="TPR" entity-name="mantle.party.PartyRelationship" join-from-alias="WEP" join-optional="true">
+            <key-map field-name="partyId" related="toPartyId"/></member-entity>
         <member-entity entity-alias="WEAA" entity-name="mantle.work.effort.WorkEffortAssetAssign" join-from-alias="WEFF" join-optional="true">
             <key-map field-name="workEffortId"/></member-entity>
         <alias-all entity-alias="WEFF"><exclude field="workTypeEnumId"/></alias-all>
         <alias-all entity-alias="WEP"><exclude field="fromDate"/><exclude field="thruDate"/><exclude field="statusId"/></alias-all>
         <alias-all entity-alias="WEAA"><exclude field="fromDate"/><exclude field="thruDate"/><exclude field="statusId"/>
             <exclude field="comments"/></alias-all>
+        <alias-all entity-alias="TPR" prefix="teamRelationship"/>
         <alias name="partyStatusId" entity-alias="WEP" field="statusId"/>
         <alias name="partyFromDate" entity-alias="WEP" field="fromDate"/>
         <alias name="partyThruDate" entity-alias="WEP" field="thruDate"/>
         <alias name="assetStatusId" entity-alias="WEP" field="statusId"/>
         <alias name="assetFromDate" entity-alias="WEP" field="fromDate"/>
         <alias name="assetThruDate" entity-alias="WEP" field="thruDate"/>
+        <alias name="teamMemberPartyId" entity-alias="TPR" field="fromPartyId"/>
         <relationship type="one" title="WorkEffortPurpose" related="moqui.basic.Enumeration">
             <key-map field-name="purposeEnumId"/></relationship>
     </view-entity>

--- a/service/mantle/work/EventServices.xml
+++ b/service/mantle/work/EventServices.xml
@@ -70,6 +70,7 @@ along with this software (see the LICENSE.md file). If not, see
                     <econdition field-name="assetId" operator="in" from="assetIdSet" ignore-if-empty="true"/>
                     <econdition field-name="ownerPartyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
                     <econdition field-name="partyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
+                    <econdition field-name="teamMemberPartyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
                 </econditions>
                 <!-- for events look for start date within the range -->
                 <econditions combine="or">

--- a/service/mantle/work/TaskServices.xml
+++ b/service/mantle/work/TaskServices.xml
@@ -55,6 +55,7 @@ along with this software (see the LICENSE.md file). If not, see
                 <econditions combine="or">
                     <econdition field-name="ownerPartyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
                     <econdition field-name="partyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
+                    <econdition field-name="teamMemberPartyId" operator="in" from="partyIdSet" ignore-if-empty="true"/>
                 </econditions>
                 <!-- for tasks look for completion date within the range -->
                 <econditions combine="or">


### PR DESCRIPTION
This updates several views to expose the teamMemberParty fields, which can then be used via HiveMind, and other call paths(additional PR coming shortly)